### PR TITLE
Make Event Filters easier to make, and more.

### DIFF
--- a/JG/JohnnyGuitarNVSE.cpp
+++ b/JG/JohnnyGuitarNVSE.cpp
@@ -72,7 +72,7 @@ void MessageHandler(NVSEMessagingInterface::Message* msg)
 		break;
 	}
 	case NVSEMessagingInterface::kMessage_MainGameLoop:
-		for (const auto& EventInfo : EventsArray)
+		for (const auto& EventInfo : g_EventsArray)
 		{
 			EventInfo->AddQueuedEvents();
 			EventInfo->DeleteEvents();

--- a/JG/JohnnyGuitarNVSE.cpp
+++ b/JG/JohnnyGuitarNVSE.cpp
@@ -19,8 +19,6 @@
 #include "nvse/SafeWrite.h"
 #include "nvse/ScriptUtils.h"
 #include "misc/WorldToScreen.h"
-#include "events/LambdaVariableContext.h"
-#include "events/JohnnyEventPredefinitions.h"
 #include "misc/misc.h"
 #include "misc/EditorIDs.h"
 #include "internal/decoding.h"
@@ -36,7 +34,8 @@
 #include "functions/fn_region.h"
 #include "functions/fn_terminal.h"
 #include "functions/fn_ui.h"
-#include "events/CustomEventFilters.h"
+#include "events/LambdaVariableContext.h"
+#include "events/JohnnyEventPredefinitions.h"
 #include "events/JohnnyEvents.h"
 
 HMODULE JohnnyHandle;

--- a/JG/JohnnyGuitarNVSE.cpp
+++ b/JG/JohnnyGuitarNVSE.cpp
@@ -58,9 +58,14 @@ void MessageHandler(NVSEMessagingInterface::Message* msg)
 		ThisStdCall(0x8C17C0, g_thePlayer); // reevaluate reload speed modifiers
 		ThisStdCall(0x8C1940, g_thePlayer); // reevaluate equip speed modifiers
 
-		OnDyingHandler->FlushEventCallbacks();
-		OnLimbGoneHandler->FlushEventCallbacks();
-		OnCrosshairHandler->FlushEventCallbacks();
+		for (const auto& EventInfo : g_EventsArray)
+		{
+			if (EventInfo->GetFlags() & BaseEventInformation::eFlag_FlushOnLoad)
+			{
+				EventInfo->FlushEventCallbacks();
+			}
+		}
+			
 		bArrowKeysDisabled = false;
 		RestoreDisabledPlayerControlsHUDFlags();
 		SaveGameUMap.clear();

--- a/JG/JohnnyGuitarNVSE.h
+++ b/JG/JohnnyGuitarNVSE.h
@@ -1,6 +1,7 @@
 #include "..\..\nvse\nvse\ScriptUtils.h"
 #include <Windows.h>
 #include <unordered_map>
+#include <unordered_set>
 #pragma once
 
 NVSEArrayVarInterface* g_arrInterface = NULL;

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -59,7 +59,7 @@ public:
 		if (!FilterSet) return true;
 		return FilterSet->empty();
 	}
-	virtual bool IsFilterEqual(GenericFilters Filter, UInt32 nuFilter)
+	virtual bool IsGenFilterEqual(GenericFilters Filter, UInt32 nuFilter)
 	{
 		return (Filter.ptr == GenFilters[nuFilter].ptr);
 	}
@@ -205,7 +205,7 @@ public:
 		return isEmpty;
 	}
 	
-	bool IsFilterEqual(UInt32 filterNum, FilterTypeSets cmpFilterSet) override
+	bool IsGenFilterEqual(UInt32 filterNum, FilterTypeSets cmpFilterSet) override
 	{
 		FilterTypeSets* filterSet;
 		if (!(filterSet = GetNthGenFilter(filterNum))) return false;
@@ -254,7 +254,7 @@ public:
 	// Modifies by reference.
 	static void SetUpIntFilters(IntSet& intFilters)
 	{
-		intFilters.erase(-1);
+		intFilters.erase(g_IgnoreIntFilter);
 	}
 	
 	void SetUpFiltering() override

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -222,7 +222,6 @@ public:
 	//	return isAccepted;
 		return true;
 	}
-	//
 
 	static RefIDSet SetUpFormFilters(RefIDSet const &refIDFilters)
 	{
@@ -246,7 +245,7 @@ public:
 			}
 		}
 
-		newSet.erase(g_xMarkerID);
+		newSet.erase(kIgnFilter_RefID);
 		//newSet.erase(nullptr);	// maybe filtering to only null forms could be useful?
 		return newSet;
 	}
@@ -254,7 +253,7 @@ public:
 	// Modifies by reference.
 	static void SetUpIntFilters(IntSet& intFilters)
 	{
-		intFilters.erase(g_IgnoreIntFilter);
+		intFilters.erase(kIgnFilter_Int);
 	}
 	
 	void SetUpFiltering() override

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -11,7 +11,7 @@ class JohnnyEventFiltersOneFormOneInt : EventHandlerFilterBase
 private:
 	RefUnorderedSet* Filters = nullptr;
 
-	RefUnorderedSet* GetFilter(UInt32 filter)
+	RefUnorderedSet* GetNthFilter(UInt32 filter)
 	{
 		if (filter >= numFilters) return nullptr;
 		return &(Filters[filter]);
@@ -35,7 +35,7 @@ public:
 	virtual bool IsInFilter(UInt32 filterNum, GenericFilters toSearch)
 	{
 		RefUnorderedSet* FilterSet;
-		if (!(FilterSet = GetFilter(filterNum))) return false;
+		if (!(FilterSet = GetNthFilter(filterNum))) return false;
 		return  FilterSet->empty() || (FilterSet->find(toSearch.refID) != FilterSet->end());
 	}
 
@@ -43,19 +43,19 @@ public:
 	virtual void InsertToFilter(UInt32 filterNum, GenericFilters toInsert)
 	{
 		RefUnorderedSet* FilterSet;
-		if (!(FilterSet = GetFilter(filterNum))) return;
+		if (!(FilterSet = GetNthFilter(filterNum))) return;
 		FilterSet->insert(toInsert.refID);
 	}
 	virtual void DeleteFromFilter(UInt32 filterNum, GenericFilters toDelete)
 	{
 		RefUnorderedSet* FilterSet;
-		if (!(FilterSet = GetFilter(filterNum))) return;
+		if (!(FilterSet = GetNthFilter(filterNum))) return;
 		FilterSet->erase(toDelete.refID);
 
 	}
 	virtual bool IsFilterEmpty(UInt32 filterNum)
 	{
-		RefUnorderedSet* FilterSet = GetFilter(filterNum);
+		RefUnorderedSet* FilterSet = GetNthFilter(filterNum);
 		if (!FilterSet) return true;
 		return FilterSet->empty();
 	}
@@ -119,17 +119,17 @@ class GenericEventFilters : EventHandlerFilterBase
 public:
 	GenericEventFilters(FilterTypeSetArray &filters)
 	{
-		filtersArr = filters;
+		filtersArr = genFiltersArr = filters;
 	}
 	GenericEventFilters(FilterTypeSets& filter)
 	{
-		filtersArr = FilterTypeSetArray { filter };
+		filtersArr = genFiltersArr = FilterTypeSetArray { filter };
 	}
 
 	bool IsInFilter(UInt32 filterNum, FilterTypes toSearch) override
 	{
 		FilterTypeSets* filterSet;
-		if (!(filterSet = GetFilter(filterNum))) return false;
+		if (!(filterSet = GetNthFilter(filterNum))) return false;
 		bool const isFound = std::visit(overload{
 		[](FormSet &arg1, TESForm* &arg2) { return arg1.find(arg2) != arg1.end(); },
 		[](IntSet &arg1, int &arg2) { return arg1.find(arg2) != arg1.end(); },
@@ -148,11 +148,12 @@ public:
 		FilterTypes filter = toSearch;
 		return IsInFilter(filterNum, toSearch);
 	}
-	
+
+	// Unused
 	bool InsertToFilter(UInt32 filterNum, FilterTypes toInsert) override
 	{
 		FilterTypeSets* filterSet;
-		if (!(filterSet = GetFilter(filterNum))) return false;
+		if (!(filterSet = GetNthFilter(filterNum))) return false;
 		bool const isInserted = std::visit(overload{
 		[](FormSet& arg1, TESForm*& arg2) { return arg1.insert(arg2).second; },
 		[](IntSet& arg1, int& arg2) { return arg1.insert(arg2).second; },
@@ -162,11 +163,12 @@ public:
 			}, *filterSet, toInsert);
 		return isInserted;
 	}
-	
+
+	// Unused
 	bool DeleteFromFilter(UInt32 filterNum, FilterTypes toDelete) override
 	{
 		FilterTypeSets* filterSet;
-		if (!(filterSet = GetFilter(filterNum))) return false;
+		if (!(filterSet = GetNthFilter(filterNum))) return false;
 		bool const isDeleted = std::visit(overload{
 		[](FormSet& arg1, TESForm* &arg2) { return arg1.erase(arg2); },
 		[](IntSet& arg1, int &arg2) { return arg1.erase(arg2); },
@@ -180,11 +182,12 @@ public:
 			}, *filterSet, toDelete);
 		return isDeleted;
 	}
-	
+
+	// Unused
 	bool IsFilterEmpty(UInt32 filterNum) override
 	{
 		FilterTypeSets* filterSet;
-		if (!(filterSet = GetFilter(filterNum))) return true;	// technically empty if there is no filter
+		if (!(filterSet = GetNthFilter(filterNum))) return true;	// technically empty if there is no filter
 		bool const isEmpty = std::visit([](auto &filter) { return filter.empty(); }, *filterSet);
 		return isEmpty;
 	}
@@ -192,7 +195,7 @@ public:
 	bool IsFilterEqual(UInt32 filterNum, FilterTypeSets cmpFilterSet) override
 	{
 		FilterTypeSets* filterSet;
-		if (!(filterSet = GetFilter(filterNum))) return false;
+		if (!(filterSet = GetNthGenFilter(filterNum))) return false;
 		return cmpFilterSet == *filterSet;
 	}
 

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "GameRTTI.h"
+#include "GameRTTI.h"	// for DYNAMIC_CAST
 #include "events/EventFilteringInterface.h"
 
 #if NULL
@@ -99,7 +99,7 @@ void* __fastcall CreateOneFormOneIntFilter(void** Filters, UInt32 numFilters) {
 
 
 
-//== Demo's Generic Filter
+//== Demo's Generic Filter System
 
 // Taken from https://www.cppstories.com/2018/09/visit-variants/. Also shows up in https://gummif.github.io/blog/overloading_lambdas.html.
 template<class... Ts> struct overload : Ts...
@@ -108,9 +108,11 @@ template<class... Ts> struct overload : Ts...
 };
 template<class... Ts> overload(Ts...)->overload<Ts...>;
 
+/*
 FilterTypeSets testFilter1 = { IntSet {5, 0x7} };
-FilterTypeSets testFilter2 = { StringSet {"testStr", "testStr2", "tt"} };
+FilterTypeSets testFilter2 = { StringSet {"testStr", "testStr2", "tt"}};
 FilterTypeSetArray testFilters = { testFilter1, testFilter2 };
+*/
 
 class GenericEventFilters : EventHandlerFilterBase
 {
@@ -249,26 +251,3 @@ public:
 void* __fastcall GenericCreateFilters(FilterTypeSetArray &filters) {
 	return new GenericEventFilters(filters);
 }
-
-
-struct EventFilter_OneForm {
-	TESForm* form = nullptr;
-
-	FilterTypeSetArray ToFilter() const
-	{
-		FormSet formSet{ form };
-		return FilterTypeSetArray{ formSet };
-	}
-};
-
-struct EventFilter_OneForm_OneInt {
-	TESForm* form = nullptr;
-	int intID = -1;
-
-	FilterTypeSetArray ToFilter() const
-	{
-		FormSet formSet{ form };
-		IntSet idSet{ intID };
-		return FilterTypeSetArray{ formSet, idSet };
-	}
-};

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -195,8 +195,8 @@ public:
 		if (size == 1)
 		{
 			bool isEqual;
-			std::visit([&size](auto& filter) { size = filter.size(); }, *filterSet);
-			//return (Filter.ptr == GenFilters[nuFilter].ptr);
+			//std::visit([&isEqual](auto& filter) { isEqual = filter.size(); }, *filterSet); //todo
+			return isEqual;
 		}
 		//if (size == 0)
 		return cmpFilter.valueless_by_exception() ? true : false;

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "GameForms.h"
 #include "GameRTTI.h"	// for DYNAMIC_CAST
 #include "events/EventFilteringInterface.h"
 

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -218,7 +218,8 @@ public:
 			std::visit(overload{
 			[](FormSet &filter)
 			{
-				FormSet newSet;
+				FormSet newSet;	// To avoid iterator invalidation by adding mid-loop, + inconsistent behavior with deep form-lists.
+				
 				// Append forms that were inside form-lists to newSet.
 				// Note: does not support deep form-lists.
 				for (auto const &formIter : filter)
@@ -236,6 +237,7 @@ public:
 					}
 				}
 				newSet.erase(LookupFormByID(g_xMarkerID));	// todo: refactor to use IsAcceptedParameter instead?
+				//newSet.erase(nullptr);	// maybe filtering to only null forms could be useful?
 				filter = newSet;	// todo: check if filterSet needs to be captured and set instead.
 			},
 			[](IntSet &filter)

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -101,6 +101,7 @@ void* __fastcall CreateOneFormOneIntFilter(void** Filters, UInt32 numFilters) {
 
 //== Demo's Generic Filter System
 
+
 // Taken from https://www.cppstories.com/2018/09/visit-variants/. Also shows up in https://gummif.github.io/blog/overloading_lambdas.html.
 template<class... Ts> struct overload : Ts...
 {
@@ -108,11 +109,6 @@ template<class... Ts> struct overload : Ts...
 };
 template<class... Ts> overload(Ts...)->overload<Ts...>;
 
-/*
-FilterTypeSets testFilter1 = { IntSet {5, 0x7} };
-FilterTypeSets testFilter2 = { StringSet {"testStr", "testStr2", "tt"}};
-FilterTypeSetArray testFilters = { testFilter1, testFilter2 };
-*/
 
 class GenericEventFilters : EventHandlerFilterBase
 {

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -1,23 +1,23 @@
 #pragma once
+
+#if NULL
 class JohnnyEventFiltersOneFormOneInt : EventHandlerInterface
 {
 
 
 	typedef  std::unordered_set<unsigned int> RefUnorderedSet;
 private:
-	RefUnorderedSet* Filters = 0;
+	RefUnorderedSet* Filters = nullptr;
 
 	RefUnorderedSet* GetFilter(UInt32 filter)
 	{
-		if (filter >= numFilters) return NULL;
+		if (filter >= numFilters) return nullptr;
 		return &(Filters[filter]);
 	}
 public:
 
-
 	JohnnyEventFiltersOneFormOneInt(void** filters, UInt32 nuFilters)
 	{
-
 		numFilters = nuFilters;
 		Filters = new RefUnorderedSet[numFilters];
 		GenFilters = new GenericFilters[numFilters];
@@ -95,3 +95,139 @@ struct EventFilterStructOneFormOneInt {
 	TESForm* form;
 	int intID;
 };
+#endif
+
+
+
+//== Demo's Generic Filter
+
+// Taken from https://www.cppstories.com/2018/09/visit-variants/. Also shows up in https://gummif.github.io/blog/overloading_lambdas.html.
+template<class... Ts> struct overload : Ts...
+{
+	using Ts::operator()...;
+};
+template<class... Ts> overload(Ts...)->overload<Ts...>;
+
+FilterTypeSets testFilter1 = { RefIDSet {5, 0x7} };
+FilterTypeSets testFilter2 = { StringSet {"testStr", "testStr2", "tt"} };
+FilterTypeSetArray testFilters = { testFilter1, testFilter2 };
+
+class GenericEventFilters : EventHandlerInterface
+{
+public:
+	GenericEventFilters(FilterTypeSetArray &filters)
+	{
+		filtersArr = filters;
+	}
+	GenericEventFilters(FilterTypeSets& filter)
+	{
+		filtersArr = FilterTypeSetArray { filter };
+	}
+
+	bool IsInFilter(UInt32 filterNum, FilterTypes toSearch) override
+	{
+		FilterTypeSets* filterSet;
+		if (!(filterSet = GetFilter(filterNum))) return false;
+		bool isFound;
+		std::visit(overload{
+		[&isFound](RefIDSet& arg1, RefID& arg2) { isFound = arg1.find(arg2) != arg1.end(); },
+		[&isFound](FormSet &arg1, TESForm* &arg2) { isFound = arg1.find(arg2) != arg1.end(); },
+		[&isFound](IntSet &arg1, int &arg2) { isFound = arg1.find(arg2) != arg1.end(); },
+		[&isFound](FloatSet &arg1, float &arg2) { isFound = arg1.find(arg2) != arg1.end(); },
+		[&isFound](StringSet &arg1, std::string &arg2) { isFound = arg1.find(arg2) != arg1.end(); },
+		[&isFound](auto &arg1, auto &arg2) {isFound = false; /*Types do not match*/ },
+			},	*filterSet, toSearch);
+		return isFound;
+	}
+	
+	bool InsertToFilter(UInt32 filterNum, FilterTypes toInsert) override
+	{
+		FilterTypeSets* filterSet;
+		if (!(filterSet = GetFilter(filterNum))) return false;
+		bool isInserted;
+		std::visit(overload{
+		[&isInserted](RefIDSet& arg1, RefID& arg2) { isInserted = arg1.insert(arg2).second; },
+		[&isInserted](FormSet& arg1, TESForm*& arg2) { isInserted = arg1.insert(arg2).second; },
+		[&isInserted](IntSet& arg1, int& arg2) { isInserted = arg1.insert(arg2).second; },
+		[&isInserted](FloatSet& arg1, float& arg2) { isInserted = arg1.insert(arg2).second; },
+		[&isInserted](StringSet& arg1, std::string& arg2) { isInserted = arg1.insert(arg2).second; },
+		[&isInserted](auto& arg1, auto& arg2) {isInserted = false; /*Types do not match*/ },
+			}, *filterSet, toInsert);
+		return isInserted;
+	}
+	
+	bool DeleteFromFilter(UInt32 filterNum, FilterTypes toDelete) override
+	{
+		FilterTypeSets* filterSet;
+		if (!(filterSet = GetFilter(filterNum))) return false;
+		bool isDeleted;
+		std::visit(overload{
+		[&isDeleted](RefIDSet& arg1, RefID& arg2) { isDeleted = arg1.erase(arg2); },
+		[&isDeleted](FormSet& arg1, TESForm*& arg2) { isDeleted = arg1.erase(arg2); },
+		[&isDeleted](IntSet& arg1, int& arg2) { isDeleted = arg1.erase(arg2); },
+		[&isDeleted](FloatSet& arg1, float& arg2) { isDeleted = arg1.erase(arg2); },
+		[&isDeleted](StringSet& arg1, std::string& arg2) { isDeleted = arg1.erase(arg2); },
+		[&isDeleted](auto& arg1, auto& arg2) {isDeleted = false; /*Types do not match*/ },
+			}, *filterSet, toDelete);
+		return isDeleted;
+	}
+	
+	bool IsFilterEmpty(UInt32 filterNum) override
+	{
+		FilterTypeSets* filterSet;
+		if (!(filterSet = GetFilter(filterNum))) return true;	// technically empty if there is no filter
+		bool isEmpty;
+		std::visit([&isEmpty](auto &filter) { isEmpty = filter.empty(); }, *filterSet);
+		return isEmpty;
+	}
+	
+	bool IsFilterEqual(UInt32 filterNum, FilterTypes cmpFilter) override
+	{
+		FilterTypeSets* filterSet;
+		if (!(filterSet = GetFilter(filterNum)))
+		{
+			if (cmpFilter.valueless_by_exception()) return true;	// rare case
+			return false;
+		}
+		UInt32 size;
+		std::visit([&size](auto& filter) { size = filter.size(); }, *filterSet);
+		if (size > 1) return false;	// comparing a single value to an array of values.
+		if (size == 1)
+		{
+			bool isEqual;
+			std::visit([&size](auto& filter) { size = filter.size(); }, *filterSet);
+			//return (Filter.ptr == GenFilters[nuFilter].ptr);
+		}
+		//if (size == 0)
+		return cmpFilter.valueless_by_exception() ? true : false;
+	}
+	/*
+	bool IsAcceptedParameter(FilterTypes parameter) override
+	{
+		return parameter.form->refID != 0x3B; // xMarker
+	}
+
+	void SetUpFiltering() override
+	{
+		if (GenFilters[1].intVal != -1) InsertToFilter(1, GenFilters[1].intVal);
+		TESForm* currentFilter = GenFilters[0].form;
+		if (!currentFilter) return;
+		if (IS_TYPE(currentFilter, BGSListForm))
+		{
+			ListNode<TESForm>* iterator = ((BGSListForm*)currentFilter)->list.Head();
+			do {
+				TESForm* it = iterator->data;
+				if (IsAcceptedParameter(it))
+					InsertToFilter(0, it->refID);
+			} while (iterator = iterator->next);
+		}
+		else if (IsAcceptedParameter(currentFilter)) 
+			InsertToFilter(0, currentFilter->refID);
+	}
+	*/
+
+};
+void* __fastcall CreateGenericFilters(void** Filters, UInt32 numFilters) {
+	//todo: return new GenericEventFilters(Filters, numFilters);
+}
+	

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #if NULL
-class JohnnyEventFiltersOneFormOneInt : EventHandlerInterface
+class JohnnyEventFiltersOneFormOneInt : EventHandlerFilterBase
 {
 
 
@@ -112,7 +112,7 @@ FilterTypeSets testFilter1 = { IntSet {5, 0x7} };
 FilterTypeSets testFilter2 = { StringSet {"testStr", "testStr2", "tt"} };
 FilterTypeSetArray testFilters = { testFilter1, testFilter2 };
 
-class GenericEventFilters : EventHandlerInterface
+class GenericEventFilters : EventHandlerFilterBase
 {
 public:
 	GenericEventFilters(FilterTypeSetArray &filters)
@@ -182,14 +182,15 @@ public:
 	}
 
 	//	Unused in SetUpFiltering, so it's useless.
-	//bool IsAcceptedParameter(FilterTypes param) override
-	//{
+	bool IsAcceptedParameter(FilterTypes param) override
+	{
 	//	bool const isAccepted = std::visit(overload{
 	//		[&](TESForm* &filter) { return filter->refID != g_xMarkerID; },
 	//		[&](auto& filter) { return true; } /*Default case*/
 	//		}, param);
 	//	return isAccepted;
-	//}
+		return true;
+	}
 	//
 	
 	void SetUpFiltering() override
@@ -232,9 +233,7 @@ public:
 	}
 };
 
-/*
-void* __fastcall CreateGenericFilters(void** Filters, UInt32 numFilters) {
-	return new GenericEventFilters(Filters, numFilters);
+void* __fastcall CreateGenericFilters(FilterTypeSetArray &filters) {
+	return new GenericEventFilters(filters);
 }
-*/
 	

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -217,9 +217,9 @@ public:
 	static bool IsDefaultFilterValue(FilterTypes const &filterVal)
 	{
 		bool const isDefault = std::visit(overload{
-		[&](RefID &filter) { return filter == kIgnFilter_FormID; },
-		[&](int filter) { return filter == kIgnFilter_Int; },
-		[&](auto& filter) { return true; } /*Default case*/
+		[](RefID filter) { return filter == kIgnFilter_FormID; },
+		[](int filter) { return filter == kIgnFilter_Int; },
+		[](auto& filter) { return false; } /*Default case*/
 		}, filterVal);
 		return isDefault;
 	}
@@ -229,7 +229,7 @@ public:
 		FilterTypeSets* filterSet;
 		if (!(filterSet = GetNthGenFilter(filterNum))) return false;
 		bool const isEqual = std::visit(
-		[](auto& genSet, auto& cmpSet)	/*Types do not match*/
+		[](auto& genSet, auto& cmpSet)
 		{
 			// Use std::decay_t to remove const type from comparison.
 			if constexpr (std::is_same_v<std::decay_t<decltype(genSet)>, std::decay_t<decltype(cmpSet)>>)
@@ -240,7 +240,7 @@ public:
 				auto setElemIter = genSet.begin();
 				for (auto cmpElemIter = cmpSet.begin(); setElemIter != genSet.end(); ++setElemIter, ++cmpElemIter)
 				{
-					if (IsDefaultFilterValue(*setElemIter))
+					if (IsDefaultFilterValue(*cmpElemIter))
 						continue;
 					if (*setElemIter != *cmpElemIter)
 						return false;

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -181,34 +181,28 @@ public:
 		return isEmpty;
 	}
 	
-	bool IsFilterEqual(UInt32 filterNum, FilterTypes cmpFilter) override
+	bool IsFilterEqual(UInt32 filterNum, FilterTypeSets cmpFilterSet) override
 	{
 		FilterTypeSets* filterSet;
-		if (!(filterSet = GetFilter(filterNum)))
-		{
-			if (cmpFilter.valueless_by_exception()) return true;	// rare case
-			return false;
-		}
-		UInt32 size;
-		std::visit([&size](auto& filter) { size = filter.size(); }, *filterSet);
-		if (size > 1) return false;	// comparing a single value to an array of values.
-		if (size == 1)
-		{
-			bool isEqual;
-			//std::visit([&isEqual](auto& filter) { isEqual = filter.size(); }, *filterSet); //todo
-			return isEqual;
-		}
-		//if (size == 0)
-		return cmpFilter.valueless_by_exception() ? true : false;
+		if (!(filterSet = GetFilter(filterNum))) return false;
+		return cmpFilterSet == *filterSet;
 	}
-	/*
-	bool IsAcceptedParameter(FilterTypes parameter) override
+	
+	bool IsAcceptedParameter(FilterTypes param) override
 	{
-		return parameter.form->refID != 0x3B; // xMarker
+		bool isAccepted;
+		UInt32 const xMarkerID = 0x3B;
+		std::visit(overload{
+			[&](TESForm* &filter) { isAccepted = filter->refID != xMarkerID; },
+			[&](RefID &filter) { isAccepted = filter != xMarkerID; },
+			[&](auto& filter) { isAccepted = true; } /*Default case*/
+			}, param);
+		return isAccepted;
 	}
-
+	
 	void SetUpFiltering() override
 	{
+		/* TODO
 		if (GenFilters[1].intVal != -1) InsertToFilter(1, GenFilters[1].intVal);
 		TESForm* currentFilter = GenFilters[0].form;
 		if (!currentFilter) return;
@@ -223,10 +217,10 @@ public:
 		}
 		else if (IsAcceptedParameter(currentFilter)) 
 			InsertToFilter(0, currentFilter->refID);
+		*/
 	}
-	*/
-
 };
+
 void* __fastcall CreateGenericFilters(void** Filters, UInt32 numFilters) {
 	//todo: return new GenericEventFilters(Filters, numFilters);
 }

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -90,12 +90,10 @@ public:
 void* __fastcall CreateOneFormOneIntFilter(void** Filters, UInt32 numFilters) {
 	return new JohnnyEventFiltersOneFormOneInt(Filters, numFilters);
 }
-
-struct EventFilterStructOneFormOneInt {
-	TESForm* form;
-	int intID;
-};
 #endif
+
+
+
 
 
 
@@ -136,6 +134,15 @@ public:
 		[](auto &arg1, auto &arg2) { return false; /*Types do not match*/ },
 			},	*filterSet, toSearch);
 		return isFound;
+	}
+
+	bool IsBaseInFilter(UInt32 filterNum, TESForm* toSearch)
+	{
+		if (!toSearch) return false;
+		if (toSearch->GetIsReference())
+			toSearch = ((TESObjectREFR*)toSearch)->baseForm;
+		FilterTypes filter = toSearch;
+		return IsInFilter(filterNum, toSearch);
 	}
 	
 	bool InsertToFilter(UInt32 filterNum, FilterTypes toInsert) override
@@ -236,4 +243,26 @@ public:
 void* __fastcall CreateGenericFilters(FilterTypeSetArray &filters) {
 	return new GenericEventFilters(filters);
 }
-	
+
+
+struct EventFilter_OneForm {
+	TESForm* form = nullptr;
+
+	FilterTypeSetArray ToFilter() const
+	{
+		FormSet formSet{ form };
+		return FilterTypeSetArray{ formSet };
+	}
+};
+
+struct EventFilter_OneForm_OneInt {
+	TESForm* form = nullptr;
+	int intID = -1;
+
+	FilterTypeSetArray ToFilter() const
+	{
+		FormSet formSet{ form };
+		IntSet idSet{ intID };
+		return FilterTypeSetArray{ formSet, idSet };
+	}
+};

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -102,6 +102,7 @@ void* __fastcall CreateOneFormOneIntFilter(void** Filters, UInt32 numFilters) {
 //== Demo's Generic Filter System
 
 
+// Allow overloading lambda functions, used for std::visit on std::variants.
 // Taken from https://www.cppstories.com/2018/09/visit-variants/. Also shows up in https://gummif.github.io/blog/overloading_lambdas.html.
 template<class... Ts> struct overload : Ts...
 {

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -1,4 +1,6 @@
 #pragma once
+#include "GameRTTI.h"
+#include "events/EventFilteringInterface.h"
 
 #if NULL
 class JohnnyEventFiltersOneFormOneInt : EventHandlerFilterBase
@@ -168,7 +170,11 @@ public:
 		[](IntSet& arg1, int &arg2) { return arg1.erase(arg2); },
 		[](FloatSet& arg1, float &arg2) { return arg1.erase(arg2); },
 		[](StringSet& arg1, std::string &arg2) { return arg1.erase(arg2); },
-		[](auto& arg1, auto& arg2) {return false; /*Types do not match*/ },
+		[](auto& arg1, auto& arg2)	/*Types do not match*/
+		{
+			size_t const t = 0;
+			return t;
+		},
 			}, *filterSet, toDelete);
 		return isDeleted;
 	}
@@ -240,7 +246,7 @@ public:
 	}
 };
 
-void* __fastcall CreateGenericFilters(FilterTypeSetArray &filters) {
+void* __fastcall GenericCreateFilters(FilterTypeSetArray &filters) {
 	return new GenericEventFilters(filters);
 }
 

--- a/JG/events/CustomEventFilters.h
+++ b/JG/events/CustomEventFilters.h
@@ -127,10 +127,10 @@ public:
 		FilterTypeSets* filterSet;
 		if (!(filterSet = GetNthFilter(filterNum))) return false;
 		bool const isFound = std::visit(overload{
-		[](RefIDSet &arg1, RefID &arg2) { return arg1.find(arg2) != arg1.end(); },
-		[](IntSet &arg1, int &arg2) { return arg1.find(arg2) != arg1.end(); },
-		[](FloatSet &arg1, float &arg2) { return arg1.find(arg2) != arg1.end(); },
-		[](StringSet &arg1, std::string &arg2) { return arg1.find(arg2) != arg1.end(); },
+		[](RefIDSet &arg1, RefID &arg2) { return arg1.empty() || arg1.find(arg2) != arg1.end(); },
+		[](IntSet &arg1, int &arg2) { return arg1.empty() || arg1.find(arg2) != arg1.end(); },
+		[](FloatSet &arg1, float &arg2) { return arg1.empty() || arg1.find(arg2) != arg1.end(); },
+		[](StringSet &arg1, std::string &arg2) { return arg1.empty() || arg1.find(arg2) != arg1.end(); },
 		[](auto &arg1, auto &arg2) { return false; /*Types do not match*/ },
 			},	*filterSet, toSearch);
 		return isFound;
@@ -140,7 +140,7 @@ public:
 		FilterTypeSets* filterSet;
 		if (!(filterSet = GetNthFilter(filterNum))) return false;
 		bool const isFound = std::visit(overload{
-		[&toSearch](RefIDSet& set) { return set.find(toSearch->refID) != set.end(); },
+		[&toSearch](RefIDSet& set) { return set.empty() || set.find(toSearch->refID) != set.end(); },
 		[](auto& set) { return false; /*Types do not match*/ },
 			}, *filterSet);
 		return isFound;
@@ -159,7 +159,7 @@ public:
 		if (!toSearch) return false;
 		if (toSearch->GetIsReference())
 			toSearch = ((TESObjectREFR*)toSearch)->baseForm;
-		return IsInFilter(filterNum, toSearch->refID);
+		return IsInFilter(filterNum, toSearch);
 	}
 
 	// Unused
@@ -261,7 +261,7 @@ public:
 		// Filters out all -1 values from IntSets.
 		// Transforms all BGSListForm*-type TESForm* into the TESForm* that were contained.
 		// Filters out xMarker refs.
-		for (auto& filterSet : filtersArr)
+		for (auto &filterSetIter : filtersArr )
 		{
 			std::visit(overload{
 			[](RefIDSet &filter)
@@ -273,7 +273,7 @@ public:
 				SetUpIntFilters(filter);
 			},
 			[](auto &filter) { return; } /*Default case*/
-				}, filterSet);
+				}, filterSetIter);
 		}
 	}
 };

--- a/JG/events/EventFilterStructs.h
+++ b/JG/events/EventFilterStructs.h
@@ -1,23 +1,36 @@
 ﻿#pragma once
 #include "events/EventFilteringInterface.h"
 
-struct EventFilter_OneForm {
+// In order to enforce having the ToFilter() method.
+struct EventFilter_BaseStruct
+{
+	virtual ~EventFilter_BaseStruct() = default;
+	[[nodiscard]] virtual FilterTypeSetArray ToFilter() const = 0;
+};
+
+struct EventFilter_OneForm : EventFilter_BaseStruct
+{
 	TESForm* form = nullptr;
 
-	[[nodiscard]] FilterTypeSetArray ToFilter() const
+	[[nodiscard]] FilterTypeSetArray ToFilter() const override
 	{
-		FormSet formSet{ form };
+		RefID refID = g_xMarkerID;
+		if (form) refID = form->refID;
+		RefIDSet formSet{ refID };
 		return FilterTypeSetArray{ formSet };
 	}
 };
 
-struct EventFilter_OneForm_OneInt {
+struct EventFilter_OneForm_OneInt : EventFilter_BaseStruct
+{
 	TESForm* form = nullptr;
 	int intID = -1;
 
-	[[nodiscard]] FilterTypeSetArray ToFilter() const
+	[[nodiscard]] FilterTypeSetArray ToFilter() const override
 	{
-		FormSet formSet{ form };
+		RefID refID = g_xMarkerID;
+		if (form) refID = form->refID;
+		RefIDSet formSet{ refID };
 		IntSet idSet{ intID };
 		return FilterTypeSetArray{ formSet, idSet };
 	}

--- a/JG/events/EventFilterStructs.h
+++ b/JG/events/EventFilterStructs.h
@@ -1,0 +1,24 @@
+﻿#pragma once
+#include "events/EventFilteringInterface.h"
+
+struct EventFilter_OneForm {
+	TESForm* form = nullptr;
+
+	FilterTypeSetArray ToFilter() const
+	{
+		FormSet formSet{ form };
+		return FilterTypeSetArray{ formSet };
+	}
+};
+
+struct EventFilter_OneForm_OneInt {
+	TESForm* form = nullptr;
+	int intID = -1;
+
+	FilterTypeSetArray ToFilter() const
+	{
+		FormSet formSet{ form };
+		IntSet idSet{ intID };
+		return FilterTypeSetArray{ formSet, idSet };
+	}
+};

--- a/JG/events/EventFilterStructs.h
+++ b/JG/events/EventFilterStructs.h
@@ -9,7 +9,6 @@ struct EventFilter_Null : EventFilter_Base
 	}
 };
 
-
 struct EventFilter_OneForm : EventFilter_Base
 {
 	TESForm* form = nullptr;

--- a/JG/events/EventFilterStructs.h
+++ b/JG/events/EventFilterStructs.h
@@ -4,7 +4,7 @@
 struct EventFilter_OneForm {
 	TESForm* form = nullptr;
 
-	FilterTypeSetArray ToFilter() const
+	[[nodiscard]] FilterTypeSetArray ToFilter() const
 	{
 		FormSet formSet{ form };
 		return FilterTypeSetArray{ formSet };
@@ -15,7 +15,7 @@ struct EventFilter_OneForm_OneInt {
 	TESForm* form = nullptr;
 	int intID = -1;
 
-	FilterTypeSetArray ToFilter() const
+	[[nodiscard]] FilterTypeSetArray ToFilter() const
 	{
 		FormSet formSet{ form };
 		IntSet idSet{ intID };

--- a/JG/events/EventFilterStructs.h
+++ b/JG/events/EventFilterStructs.h
@@ -14,7 +14,7 @@ struct EventFilter_OneForm : EventFilter_BaseStruct
 
 	[[nodiscard]] FilterTypeSetArray ToFilter() const override
 	{
-		RefID refID = g_xMarkerID;
+		RefID refID = kIgnFilter_RefID;
 		if (form) refID = form->refID;
 		RefIDSet formSet{ refID };
 		return FilterTypeSetArray{ formSet };
@@ -24,11 +24,11 @@ struct EventFilter_OneForm : EventFilter_BaseStruct
 struct EventFilter_OneForm_OneInt : EventFilter_BaseStruct
 {
 	TESForm* form = nullptr;
-	int intID = g_IgnoreIntFilter;
+	int intID = kIgnFilter_Int;
 
 	[[nodiscard]] FilterTypeSetArray ToFilter() const override
 	{
-		RefID refID = g_xMarkerID;
+		RefID refID = kIgnFilter_RefID;
 		if (form) refID = form->refID;
 		RefIDSet formSet{ refID };
 		IntSet idSet{ intID };

--- a/JG/events/EventFilterStructs.h
+++ b/JG/events/EventFilterStructs.h
@@ -1,14 +1,16 @@
 ﻿#pragma once
 #include "events/EventFilteringInterface.h"
 
-// In order to enforce having the ToFilter() method.
-struct EventFilter_BaseStruct
+struct EventFilter_Null : EventFilter_Base
 {
-	virtual ~EventFilter_BaseStruct() = default;
-	[[nodiscard]] virtual FilterTypeSetArray ToFilter() const = 0;
+	[[nodiscard]] FilterTypeSetArray ToFilter() const override
+	{
+		return FilterTypeSetArray{};
+	}
 };
 
-struct EventFilter_OneForm : EventFilter_BaseStruct
+
+struct EventFilter_OneForm : EventFilter_Base
 {
 	TESForm* form = nullptr;
 
@@ -21,7 +23,7 @@ struct EventFilter_OneForm : EventFilter_BaseStruct
 	}
 };
 
-struct EventFilter_OneForm_OneInt : EventFilter_BaseStruct
+struct EventFilter_OneForm_OneInt : EventFilter_Base
 {
 	TESForm* form = nullptr;
 	int intID = kIgnFilter_Int;

--- a/JG/events/EventFilterStructs.h
+++ b/JG/events/EventFilterStructs.h
@@ -24,7 +24,7 @@ struct EventFilter_OneForm : EventFilter_BaseStruct
 struct EventFilter_OneForm_OneInt : EventFilter_BaseStruct
 {
 	TESForm* form = nullptr;
-	int intID = -1;
+	int intID = g_IgnoreIntFilter;
 
 	[[nodiscard]] FilterTypeSetArray ToFilter() const override
 	{

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -2,7 +2,6 @@
 #include <variant>
 #include <unordered_set>
 #include "PluginAPI.h"
-#include "GameForms.h"
 #include "events/LambdaVariableContext.h"
 
 using RefID = UInt32;
@@ -34,7 +33,7 @@ using FilterTypeSetArray = std::vector<FilterTypeSets>;
 
 static_assert(std::variant_size_v<FilterTypeSets> == std::variant_size_v<FilterTypes>);
 
-#if NULL // Use examples:
+#if NULL //examples:
 	FilterTypeSets testFilter1 = { IntSet {5, 0x7} };
 	FilterTypeSets testFilter2 = { StringSet {"testStr", "testStr2", "tt"}};
 	FilterTypeSetArray testFilters = { testFilter1, testFilter2 };

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -21,13 +21,13 @@ using FilterTypeSetArray = std::vector<FilterTypeSets>;
 
 static_assert(std::variant_size_v<FilterTypeSets> == std::variant_size_v<FilterTypes>);
 
-class EventHandlerInterface
+class EventHandlerFilterBase
 {
 public:
 	FilterTypeSetArray filtersArr;
 	
 	// Framework passes the objects to add to filter here
-	virtual ~EventHandlerInterface() = default;
+	virtual ~EventHandlerFilterBase() = default;
 	
 	// Used to filter out "-1" int codes, transform a form-list TESForm* into a bunch of TESForm*s, etc.
 	// Alternatively, can set up one's own data structures here.
@@ -70,7 +70,7 @@ public:
 	void virtual RemoveEvent(Script* script, void** filters);
 };
 
-EventContainerInterface* (_cdecl* CreateScriptEvent)(const char* EventName, UInt8 maxArgs, UInt8 maxFilters, void* (__fastcall* CustomConstructor)(void**, UInt32));
+EventContainerInterface* (_cdecl* CreateScriptEvent)(const char* event_name, UInt8 maxArgs, UInt8 maxFilters, void* (__fastcall* CustomConstructor)(void**, UInt32));
 void(__cdecl* FreeScriptEvent)(EventContainerInterface*& toRemove);
 */
 
@@ -79,7 +79,7 @@ class BaseEventClass
 public:
 	ULONG_PTR Flags = 0;
 	Script* ScriptForEvent = NULL;
-	EventHandlerInterface* eventFilter = NULL;
+	EventHandlerFilterBase* eventFilter = NULL;
 	LambdaVariableContext capturedLambdaVars;
 
 	BaseEventClass() : capturedLambdaVars(nullptr){}

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <variant>
 #include <unordered_set>
+#include "PluginAPI.h"
+#include "GameForms.h"
+#include "events/LambdaVariableContext.h"
 
 //using RefID = UInt32;
 UInt32 const g_xMarkerID = 0x3B;

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -2,55 +2,58 @@
 #include <variant>
 #include <unordered_set>
 
-using RefID = UInt32;	// todo: place higher in the include order.
+//using RefID = UInt32;
+UInt32 const g_xMarkerID = 0x3B;
 
-using FilterTypes = std::variant<RefID, TESForm*, int, float, std::string>;
-//using FilterTypeSet = std::unordered_set<FilterTypes>; // too flexible
+using FilterTypes = std::variant<TESForm*, int, float, std::string>;
 
-// Set shortcuts 
+// If there are more than 1 item per filter, will search for any match.
+// Example: can fill an IntSet with multiple EquipSlot codes, and if any are matched, then event handler will fire.
 using StringSet = std::unordered_set<std::string>;
 using FloatSet = std::unordered_set<float>;
 using IntSet = std::unordered_set<int>;
 using FormSet = std::unordered_set<TESForm*>;
-using RefIDSet = std::unordered_set<RefID>;
+//using RefIDSet = std::unordered_set<RefID>;
+// Removed support for direct RefIDs, as it is cumbersome to look-up the form each time to check if it's a form-list.
 
-using FilterTypeSets = std::variant<RefIDSet, FormSet, IntSet, FloatSet, StringSet>;
+using FilterTypeSets = std::variant<FormSet, IntSet, FloatSet, StringSet>;
 using FilterTypeSetArray = std::vector<FilterTypeSets>;
 
 static_assert(std::variant_size_v<FilterTypeSets> == std::variant_size_v<FilterTypes>);
-// todo: Assert that for each type in FilterTypes, the matching base type from FilterTypeSets must have the same index.
-//static_assert(std::is_same_v<RefID, std::variant_alternative_t<0, FilterTypes>>);
-/*static_assert(std::is_same_v<
-	std::decltype(std::declval<std::variant_alternative_t<0, FilterTypeSets>>().begin().),
-	std::variant_alternative_t<0, FilterTypes>>);*/
-//static_assert(std::is_same_v<float, std::variant_alternative_t<1, my_variant>>);
 
 class EventHandlerInterface
 {
 public:
-	FilterTypeSetArray filtersArr;
-	//Framework passes the objects to add to filter here
+	FilterTypeSetArray filtersArr;	//todo: make private?
+
+	// Framework passes the objects to add to filter here
 	virtual ~EventHandlerInterface() = default;
-	//When the framework passes filters, it passes them to the GenFilters array pointer, specifying the number of filters in the numFilters member
-	//This function is called by the framework so you can add the objects inside a struct more suitable for search, such as an unordered set
+	
+	// Used to filter out "-1" int codes, transform a form-list TESForm* into a bunch of TESForm*, etc.
 	virtual void SetUpFiltering() = 0;
 
-	//Checks if an object is in the filter, recommended to use a fast lookup data structure
+	// Checks if an object is in the filter, recommended to use a fast lookup data structure
 	virtual bool IsInFilter(UInt32 filterNum, FilterTypes toSearch) = 0;
-	//Inserts the desired element to the Nth filter.
+	
+	// Inserts the desired element to the Nth filter.
 	virtual bool InsertToFilter(UInt32 filterNum, FilterTypes toInsert) = 0;
-	//Deletes an object from the Nth filter
+	
+	// Deletes an object from the Nth filter
 	virtual bool DeleteFromFilter(UInt32 filterNum, FilterTypes toDelete) = 0;
-	//Returns if the filter is empty
+	
+	// Returns if the filter is empty
 	virtual bool IsFilterEmpty(UInt32 filterNum) = 0;
-	//Used by the framework to check if the Nth filter equals the passed value set. Useful to avoid adding the same event repeatedly
+	
+	// Used by the framework to check if the Nth filter equals the passed value set. Useful to avoid adding the same event repeatedly
 	virtual bool IsFilterEqual(UInt32 filterNum, FilterTypeSets cmpFilterSet) = 0;
-	//Function used by the filter to check if the object passed is an accepted parameter
+	
+	// Function used by the filter to check if the object passed is an accepted parameter
 	virtual bool IsAcceptedParameter(FilterTypes parameter) = 0;
-	//Hope a UInt32 is large enough.
+	
+	// Hope a UInt32 is large enough.
 	virtual UInt32 GetNumFilters() { return filtersArr.size(); }
 	
-	//numFilter is 0-indexed	//todo: add to private or w/e
+	// numFilter is 0-indexed	//todo: add to private or w/e
 	FilterTypeSets* GetFilter(UInt32 numFilter)
 	{
 		if (numFilter >= filtersArr.size()) return nullptr;
@@ -58,7 +61,7 @@ public:
 	}
 };
 
-/*
+/* UNUSED
 class EventContainerInterface
 {
 public:

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -92,40 +92,11 @@ public:
 	}
 };
 
-/* UNUSED
-class EventContainerInterface
+// All event filters should inherit from this.
+// Used by EventInformation class to ensure that the declared filter type is the same when registering/removing events.
+struct EventFilter_Base
 {
-public:
-	void virtual RegisterEvent(Script* script, void** filters);
-	void virtual RemoveEvent(Script* script, void** filters);
-};
-
-EventContainerInterface* (_cdecl* CreateScriptEvent)(const char* event_name, UInt8 maxArgs, UInt8 maxFilters, void* (__fastcall* CustomConstructor)(void**, UInt32));
-void(__cdecl* FreeScriptEvent)(EventContainerInterface*& toRemove);
-*/
-
-class BaseEventClass
-{
-public:
-	ULONG_PTR Flags = 0;
-	Script* ScriptForEvent = nullptr;
-	EventHandlerFilterBase* eventFilter = nullptr;
-	LambdaVariableContext capturedLambdaVars;
-
-	BaseEventClass() : capturedLambdaVars(nullptr){}
-
-	enum GlobalEventFlags
-	{
-		kEventFlag_Deleted = 1 << 0,
-	};
-
-	bool GetDeleted() const
-	{
-		return Flags & kEventFlag_Deleted;
-	}
-	void SetDeleted(bool doSet)
-	{
-		doSet ? Flags |= kEventFlag_Deleted : Flags &= ~kEventFlag_Deleted;
-	}
+	virtual ~EventFilter_Base() = default;
+	[[nodiscard]] virtual FilterTypeSetArray ToFilter() const = 0;
 };
 

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -5,21 +5,20 @@
 #include "GameForms.h"
 #include "events/LambdaVariableContext.h"
 
-//using RefID = UInt32;
+using RefID = UInt32;
 UInt32 const g_xMarkerID = 0x3B;
 
-using FilterTypes = std::variant<TESForm*, int, float, std::string>;
+using FilterTypes = std::variant<RefID, int, float, std::string>;
 
 // If there are more than 1 item per filter, will search for any match.
 // Example: can fill an IntSet with multiple EquipSlot codes, and if any are matched, then event handler will fire.
 using StringSet = std::unordered_set<std::string>;
 using FloatSet = std::unordered_set<float>;
 using IntSet = std::unordered_set<int>;
-using FormSet = std::unordered_set<TESForm*>;
-//using RefIDSet = std::unordered_set<RefID>;
-// Removed support for direct RefIDs, as it is cumbersome to look-up the form each time to check if it's a form-list.
+// Storing TESForm* can cause rare crashes due to dynamic refs, so use RefIDs.
+using RefIDSet = std::unordered_set<RefID>;
 
-using FilterTypeSets = std::variant<FormSet, IntSet, FloatSet, StringSet>;
+using FilterTypeSets = std::variant<RefIDSet, IntSet, FloatSet, StringSet>;
 using FilterTypeSetArray = std::vector<FilterTypeSets>;
 
 static_assert(std::variant_size_v<FilterTypeSets> == std::variant_size_v<FilterTypes>);

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -57,7 +57,7 @@ public:
 	// Hope a UInt32 is large enough.
 	virtual UInt32 GetNumFilters() { return filtersArr.size(); }
 	
-	// numFilter is 0-indexed	//todo: add to private or w/e
+	// numFilter is 0-indexed
 	FilterTypeSets* GetFilter(UInt32 numFilter)
 	{
 		if (numFilter >= filtersArr.size()) return nullptr;
@@ -81,8 +81,8 @@ class BaseEventClass
 {
 public:
 	ULONG_PTR Flags = 0;
-	Script* ScriptForEvent = NULL;
-	EventHandlerFilterBase* eventFilter = NULL;
+	Script* ScriptForEvent = nullptr;
+	EventHandlerFilterBase* eventFilter = nullptr;
 	LambdaVariableContext capturedLambdaVars;
 
 	BaseEventClass() : capturedLambdaVars(nullptr){}
@@ -92,7 +92,7 @@ public:
 		kEventFlag_Deleted = 1 << 0,
 	};
 
-	bool GetDeleted()
+	bool GetDeleted() const
 	{
 		return Flags & kEventFlag_Deleted;
 	}

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -6,12 +6,20 @@
 #include "events/LambdaVariableContext.h"
 
 using RefID = UInt32;
-
-// Ignored refID filter for GenericEventFilters.
-UInt32 const g_xMarkerID = 0x3B;
-int const g_IgnoreIntFilter = -1;
-
 using FilterTypes = std::variant<RefID, int, float, std::string>;
+
+// The following filter values are ignored by GenericEventFilters (unfiltered).
+enum IgnoreFilter_Values
+{
+	// For RefID filters
+	kIgnFilter_xMarkerID = 0x3B,
+	kIgnFilter_RefID = kIgnFilter_xMarkerID,
+	kIgnFilter_FormID = kIgnFilter_xMarkerID,
+	kIgnFilter_Form = kIgnFilter_xMarkerID,
+
+	// For int filters
+	kIgnFilter_Int = -1,
+};
 
 // If there are more than 1 item per filter, will search for any match.
 // Example: can fill an IntSet with multiple EquipSlot codes, and if any are matched, then event handler will fire.

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -6,7 +6,10 @@
 #include "events/LambdaVariableContext.h"
 
 using RefID = UInt32;
+
+// Ignored refID filter for GenericEventFilters.
 UInt32 const g_xMarkerID = 0x3B;
+int const g_IgnoreIntFilter = -1;
 
 using FilterTypes = std::variant<RefID, int, float, std::string>;
 
@@ -36,7 +39,7 @@ public:
 	FilterTypeSetArray filtersArr;
 	
 	// The original filters array that was passed, before SetUpFiltering() was called.
-	// Costs more mem, but saves us from having to deep-check form-lists when checking IsFilterEqual().
+	// Costs more mem, but saves us from having to deep-check form-lists when checking IsGenFilterEqual().
 	FilterTypeSetArray genFiltersArr; 
 	
 	// Framework passes the objects to add to filter here
@@ -59,13 +62,14 @@ public:
 	virtual bool IsFilterEmpty(UInt32 filterNum) = 0;
 	
 	// Used by the framework to check if the Nth Gen filter equals the passed value set. Useful to avoid adding the same event repeatedly
-	virtual bool IsFilterEqual(UInt32 filterNum, FilterTypeSets cmpFilterSet) = 0;
+	virtual bool IsGenFilterEqual(UInt32 filterNum, FilterTypeSets cmpFilterSet) = 0;
 	
 	// Function used by the filter to check if the object passed is an accepted parameter
 	virtual bool IsAcceptedParameter(FilterTypes parameter) = 0;
 	
 	// Hope a UInt32 is large enough.
 	virtual UInt32 GetNumFilters() { return filtersArr.size(); }
+	virtual UInt32 GetNumGenFilters() { return genFiltersArr.size(); }
 	
 	// numFilter is 0-indexed
 	FilterTypeSets* GetNthFilter(UInt32 numFilter)

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -24,12 +24,13 @@ static_assert(std::variant_size_v<FilterTypeSets> == std::variant_size_v<FilterT
 class EventHandlerInterface
 {
 public:
-	FilterTypeSetArray filtersArr;	//todo: make private?
-
+	FilterTypeSetArray filtersArr;
+	
 	// Framework passes the objects to add to filter here
 	virtual ~EventHandlerInterface() = default;
 	
-	// Used to filter out "-1" int codes, transform a form-list TESForm* into a bunch of TESForm*, etc.
+	// Used to filter out "-1" int codes, transform a form-list TESForm* into a bunch of TESForm*s, etc.
+	// Alternatively, can set up one's own data structures here.
 	virtual void SetUpFiltering() = 0;
 
 	// Checks if an object is in the filter, recommended to use a fast lookup data structure
@@ -69,9 +70,9 @@ public:
 	void virtual RemoveEvent(Script* script, void** filters);
 };
 
-
 EventContainerInterface* (_cdecl* CreateScriptEvent)(const char* EventName, UInt8 maxArgs, UInt8 maxFilters, void* (__fastcall* CustomConstructor)(void**, UInt32));
 void(__cdecl* FreeScriptEvent)(EventContainerInterface*& toRemove);
+*/
 
 class BaseEventClass
 {
@@ -94,8 +95,7 @@ public:
 	}
 	void SetDeleted(bool doSet)
 	{
-
 		doSet ? Flags |= kEventFlag_Deleted : Flags &= ~kEventFlag_Deleted;
 	}
 };
-*/
+

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -69,7 +69,12 @@ public:
 	virtual bool IsFilterEmpty(UInt32 filterNum) = 0;
 	
 	// Used by the framework to check if the Nth Gen filter equals the passed value set. Useful to avoid adding the same event repeatedly
-	virtual bool IsGenFilterEqual(UInt32 filterNum, FilterTypeSets cmpFilterSet) = 0;
+	virtual bool IsGenFilterEqual(UInt32 filterNum, FilterTypeSets const &cmpFilterSet) = 0;
+
+	// Used to check if the Nth Gen filter equals the passed value set.
+	// ALL default-value Gen filters are said to be "equal".
+	// Useful to mass-remove events by using default filters.
+	virtual bool IsGenFilterEqualAlt(UInt32 filterNum, FilterTypeSets const &cmpFilterSet) = 0;
 	
 	// Function used by the filter to check if the object passed is an accepted parameter
 	virtual bool IsAcceptedParameter(FilterTypes parameter) = 0;

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -24,6 +24,13 @@ using FilterTypeSetArray = std::vector<FilterTypeSets>;
 
 static_assert(std::variant_size_v<FilterTypeSets> == std::variant_size_v<FilterTypes>);
 
+#if NULL // Use examples:
+	FilterTypeSets testFilter1 = { IntSet {5, 0x7} };
+	FilterTypeSets testFilter2 = { StringSet {"testStr", "testStr2", "tt"}};
+	FilterTypeSetArray testFilters = { testFilter1, testFilter2 };
+#endif
+
+
 class EventHandlerFilterBase
 {
 public:

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -1,74 +1,64 @@
 #pragma once
+#include <variant>
+#include <unordered_set>
 
-union GenericFilters
-{
-	void* ptr;
-	TESForm* form;
-	UInt32        refID;
-	int            intVal;
-	float        fltVal;
-	char* str;
-	GenericFilters()
-	{
-		this->ptr = NULL;
-	}
-	GenericFilters(void* ptr)
-	{
-		this->ptr = ptr;
-	}
-	GenericFilters(TESForm* form)
-	{
-		this->form = form;
-	}
-	GenericFilters(UInt32 refID)
-	{
-		this->refID = refID;
-	}
-	GenericFilters(int intVal)
-	{
-		this->intVal = intVal;
-	}
-	GenericFilters(float fltVal)
-	{
-		this->fltVal = fltVal;
-	}
-	GenericFilters(char* str)
-	{
-		this->str = str;
-	}
+using RefID = UInt32;	// todo: place higher in the include order.
 
-};
+using FilterTypes = std::variant<RefID, TESForm*, int, float, std::string>;
+//using FilterTypeSet = std::unordered_set<FilterTypes>; // too flexible
+
+// Set shortcuts 
+using StringSet = std::unordered_set<std::string>;
+using FloatSet = std::unordered_set<float>;
+using IntSet = std::unordered_set<int>;
+using FormSet = std::unordered_set<TESForm*>;
+using RefIDSet = std::unordered_set<RefID>;
+
+using FilterTypeSets = std::variant<RefIDSet, FormSet, IntSet, FloatSet, StringSet>;
+using FilterTypeSetArray = std::vector<FilterTypeSets>;
+
+static_assert(std::variant_size_v<FilterTypeSets> == std::variant_size_v<FilterTypes>);
+// todo: Assert that for each type in FilterTypes, the matching base type from FilterTypeSets must have the same index.
+//static_assert(std::is_same_v<RefID, std::variant_alternative_t<0, FilterTypes>>);
+/*static_assert(std::is_same_v<
+	std::decltype(std::declval<std::variant_alternative_t<0, FilterTypeSets>>().begin().),
+	std::variant_alternative_t<0, FilterTypes>>);*/
+//static_assert(std::is_same_v<float, std::variant_alternative_t<1, my_variant>>);
 
 class EventHandlerInterface
 {
 public:
+	FilterTypeSetArray filtersArr;
 	//Framework passes the objects to add to filter here
-	GenericFilters* GenFilters = 0;
-	//Used to know how many filters in total (aka the size of the GenericFilters array) the filter uses
-	UInt32 numFilters = 0;
-	//Default destructor
-	virtual ~EventHandlerInterface() {};
+	virtual ~EventHandlerInterface() = default;
 	//When the framework passes filters, it passes them to the GenFilters array pointer, specifying the number of filters in the numFilters member
 	//This function is called by the framework so you can add the objects inside a struct more suitable for search, such as an unordered set
 	virtual void SetUpFiltering() = 0;
 
 	//Checks if an object is in the filter, recommended to use a fast lookup data structure
-	virtual bool IsInFilter(UInt32 filterNum, GenericFilters toSearch) = 0;
+	virtual bool IsInFilter(UInt32 filterNum, FilterTypes toSearch) = 0;
 	//Inserts the desired element to the Nth filter.
-	virtual void InsertToFilter(UInt32 filterNum, GenericFilters toInsert) = 0;
+	virtual bool InsertToFilter(UInt32 filterNum, FilterTypes toInsert) = 0;
 	//Deletes an object from the Nth filter
-	virtual void DeleteFromFilter(UInt32 filterNum, GenericFilters toDelete) = 0;
+	virtual bool DeleteFromFilter(UInt32 filterNum, FilterTypes toDelete) = 0;
 	//Returns if the filter is empty
 	virtual bool IsFilterEmpty(UInt32 filterNum) = 0;
 	//Used by the framework to check if the Nth filter equals the passed value. Useful to avoid adding the same event repeatedly
-	virtual bool IsFilterEqual(GenericFilters Filter, UInt32 filterNum) = 0;
+	virtual bool IsFilterEqual(UInt32 filterNum, FilterTypes filter) = 0;
 	//Function used by the filter to check if the object passed is an accepted parameter
-	virtual bool IsAcceptedParameter(GenericFilters toCheck) = 0;
-	virtual UInt32 GetNumFilters() { return numFilters; }
-
+	virtual bool IsAcceptedParameter(FilterTypes toCheck) = 0;
+	//Hope a UInt32 is large enough.
+	virtual UInt32 GetNumFilters() { return filtersArr.size(); }
+	
+	//numFilter is 0-indexed	//todo: add to private or w/e
+	FilterTypeSets* GetFilter(UInt32 numFilter)
+	{
+		if (numFilter >= filtersArr.size()) return nullptr;
+		return &filtersArr[numFilter];
+	}
 };
 
-
+/*
 class EventContainerInterface
 {
 public:
@@ -105,3 +95,4 @@ public:
 		doSet ? Flags |= kEventFlag_Deleted : Flags &= ~kEventFlag_Deleted;
 	}
 };
+*/

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -29,6 +29,10 @@ class EventHandlerFilterBase
 public:
 	FilterTypeSetArray filtersArr;
 	
+	// The original filters array that was passed, before SetUpFiltering() was called.
+	// Costs more mem, but saves us from having to deep-check form-lists when checking IsFilterEqual().
+	FilterTypeSetArray genFiltersArr; 
+	
 	// Framework passes the objects to add to filter here
 	virtual ~EventHandlerFilterBase() = default;
 	
@@ -48,7 +52,7 @@ public:
 	// Returns if the filter is empty
 	virtual bool IsFilterEmpty(UInt32 filterNum) = 0;
 	
-	// Used by the framework to check if the Nth filter equals the passed value set. Useful to avoid adding the same event repeatedly
+	// Used by the framework to check if the Nth Gen filter equals the passed value set. Useful to avoid adding the same event repeatedly
 	virtual bool IsFilterEqual(UInt32 filterNum, FilterTypeSets cmpFilterSet) = 0;
 	
 	// Function used by the filter to check if the object passed is an accepted parameter
@@ -58,10 +62,15 @@ public:
 	virtual UInt32 GetNumFilters() { return filtersArr.size(); }
 	
 	// numFilter is 0-indexed
-	FilterTypeSets* GetFilter(UInt32 numFilter)
+	FilterTypeSets* GetNthFilter(UInt32 numFilter)
 	{
 		if (numFilter >= filtersArr.size()) return nullptr;
 		return &filtersArr[numFilter];
+	}
+	FilterTypeSets* GetNthGenFilter(UInt32 numFilter)
+	{
+		if (numFilter >= genFiltersArr.size()) return nullptr;
+		return &genFiltersArr[numFilter];
 	}
 };
 

--- a/JG/events/EventFilteringInterface.h
+++ b/JG/events/EventFilteringInterface.h
@@ -43,10 +43,10 @@ public:
 	virtual bool DeleteFromFilter(UInt32 filterNum, FilterTypes toDelete) = 0;
 	//Returns if the filter is empty
 	virtual bool IsFilterEmpty(UInt32 filterNum) = 0;
-	//Used by the framework to check if the Nth filter equals the passed value. Useful to avoid adding the same event repeatedly
-	virtual bool IsFilterEqual(UInt32 filterNum, FilterTypes filter) = 0;
+	//Used by the framework to check if the Nth filter equals the passed value set. Useful to avoid adding the same event repeatedly
+	virtual bool IsFilterEqual(UInt32 filterNum, FilterTypeSets cmpFilterSet) = 0;
 	//Function used by the filter to check if the object passed is an accepted parameter
-	virtual bool IsAcceptedParameter(FilterTypes toCheck) = 0;
+	virtual bool IsAcceptedParameter(FilterTypes parameter) = 0;
 	//Hope a UInt32 is large enough.
 	virtual UInt32 GetNumFilters() { return filtersArr.size(); }
 	

--- a/JG/events/JohnnyEventPredefinitions.h
+++ b/JG/events/JohnnyEventPredefinitions.h
@@ -135,9 +135,9 @@ public:
 		: event_name{ std::move(eventName) }, num_max_args(numMaxArgs), num_max_filters(numMaxFilters)
 	{
 		if (!FilterCreatorFunction)
-			this->filter_creator_func = GenericCreateFilters;
+			filter_creator_func = GenericCreateFilters;
 		else
-			this->filter_creator_func = FilterCreatorFunction;
+			filter_creator_func = FilterCreatorFunction;
 	}
 	virtual ~EventInformation()
 	{
@@ -165,6 +165,10 @@ public:
 			kRetn_Continue = 1,
 			kRetn_Return = 2,
 		};
+
+		// TODO: Make this account for forms inside form-lists???
+		// todo: either store the unmodified GenFilters (pre-formlist and filtering)
+		// or... repeat those steps here somehow.
 		auto CheckFilterFunc = [&, this](BaseEventClass &eventIter) -> UInt8
 		{
 			if (script == eventIter.ScriptForEvent)
@@ -175,7 +179,7 @@ public:
 					if (!eventIter.eventFilter->IsFilterEqual(i, filters[i]))
 						return kRetn_Break;
 				}
-				return kRetn_Return; // event is already registered.
+				return kRetn_Return; // event is already registered with the same filters.
 			}
 			return kRetn_Continue;
 		};

--- a/JG/events/JohnnyEventPredefinitions.h
+++ b/JG/events/JohnnyEventPredefinitions.h
@@ -17,7 +17,7 @@ class JohnnyEventFiltersForm : EventHandlerFilterBase
 
 	RefUnorderedSet* Filters = nullptr;	// In order to search filters more efficiently.
 
-	RefUnorderedSet* GetFilter(UInt32 filter)
+	RefUnorderedSet* GetNthFilter(UInt32 filter)
 	{
 		if (filter >= numFilters) return NULL;
 		return &(Filters[filter]);
@@ -40,7 +40,7 @@ public:
 	virtual bool IsInFilter(UInt32 filterNum, GenericFilters toSearch)
 	{
 		RefUnorderedSet* FilterSet;
-		if (!(FilterSet = GetFilter(filterNum))) return false;
+		if (!(FilterSet = GetNthFilter(filterNum))) return false;
 		return FilterSet->empty() || (FilterSet->find(toSearch.refID) != FilterSet->end());
 	}
 
@@ -48,19 +48,19 @@ public:
 	virtual void InsertToFilter(UInt32 filterNum, GenericFilters toInsert)
 	{
 		RefUnorderedSet* FilterSet;
-		if (!(FilterSet = GetFilter(filterNum))) return;
+		if (!(FilterSet = GetNthFilter(filterNum))) return;
 		FilterSet->insert(toInsert.refID);
 	}
 	virtual void DeleteFromFilter(UInt32 filterNum, GenericFilters toDelete)
 	{
 		RefUnorderedSet* FilterSet;
-		if (!(FilterSet = GetFilter(filterNum))) return;
+		if (!(FilterSet = GetNthFilter(filterNum))) return;
 		FilterSet->erase(toDelete.refID);
 
 	}
 	virtual bool IsFilterEmpty(UInt32 filterNum)
 	{
-		RefUnorderedSet* FilterSet = GetFilter(filterNum);
+		RefUnorderedSet* FilterSet = GetNthFilter(filterNum);
 		if (!FilterSet) return true;
 		return FilterSet->empty();
 	}

--- a/JG/events/JohnnyEventPredefinitions.h
+++ b/JG/events/JohnnyEventPredefinitions.h
@@ -11,8 +11,7 @@ class JohnnyEventFiltersForm : EventHandlerInterface
 {
 	typedef  std::unordered_set<unsigned int> RefUnorderedSet;
 
-private:
-	RefUnorderedSet* Filters = 0;
+	RefUnorderedSet* Filters = nullptr;	// In order to search filters more efficiently.
 
 	RefUnorderedSet* GetFilter(UInt32 filter)
 	{
@@ -38,8 +37,7 @@ public:
 	{
 		RefUnorderedSet* FilterSet;
 		if (!(FilterSet = GetFilter(filterNum))) return false;
-		//RefUnorderedSet::const_iterator got = FilterSet->find(toSearch);
-		return  FilterSet->empty() || (FilterSet->find(toSearch.refID) != FilterSet->end());
+		return FilterSet->empty() || (FilterSet->find(toSearch.refID) != FilterSet->end());
 	}
 
 
@@ -155,7 +153,7 @@ public:
 	void virtual RegisterEvent(Script* script, void** filters)
 	{
 		UInt32 maxFilters = this->numMaxFilters;
-		for (std::vector<BaseEventClass>::iterator it = this->EventCallbacks.begin(); it != this->EventCallbacks.end(); ++it)
+		for (auto it = this->EventCallbacks.begin(); it != this->EventCallbacks.end(); ++it)
 		{
 			if (script == it->ScriptForEvent)
 			{
@@ -171,7 +169,7 @@ public:
 
 		}
 		std::shared_lock rLock(QueueRWLock);
-		for (std::vector<BaseEventClass>::iterator it = this->EventQueueAdd.begin(); it != this->EventQueueAdd.end(); ++it)
+		for (auto it = this->EventQueueAdd.begin(); it != this->EventQueueAdd.end(); ++it)
 		{
 
 			if (script == it->ScriptForEvent)
@@ -193,7 +191,6 @@ public:
 		NewEvent.capturedLambdaVars = LambdaVariableContext(script);
 		if (maxFilters)
 		{
-
 			*(void**)&(NewEvent.eventFilter) = this->CreateFilter(filters, maxFilters);
 			NewEvent.eventFilter->SetUpFiltering();
 		}

--- a/JG/events/JohnnyEventPredefinitions.h
+++ b/JG/events/JohnnyEventPredefinitions.h
@@ -147,7 +147,7 @@ class EventInformation : public BaseEventInformation
 					auto const maxFilters = eventFilters->GetNumGenFilters();
 					for (int i = 0; i < maxFilters; i++)
 					{
-						if (!it->eventFilter->IsGenFilterEqual(i, filters[i]))
+						if (!it->eventFilter->IsGenFilterEqualAlt(i, filters[i]))
 							goto NotFound;
 					}
 				}

--- a/JG/events/JohnnyEventPredefinitions.h
+++ b/JG/events/JohnnyEventPredefinitions.h
@@ -64,7 +64,7 @@ public:
 		if (!FilterSet) return true;
 		return FilterSet->empty();
 	}
-	virtual bool IsFilterEqual(GenericFilters Filter, UInt32 nuFilter)
+	virtual bool IsGenFilterEqual(GenericFilters Filter, UInt32 nuFilter)
 	{
 		return (Filter.ptr == GenFilters[nuFilter].ptr);
 	}
@@ -172,10 +172,10 @@ public:
 			if (script == eventIter.ScriptForEvent)
 			{
 				if (!num_max_filters) return kRetn_Return;	// filter-less event was already registered
-				if (!eventIter.eventFilter->GetNumFilters()) return kRetn_Continue;
+				if (!eventIter.eventFilter->GetNumGenFilters()) return kRetn_Continue;
 				for (int i = 0; i < num_max_filters; i++)
 				{
-					if (!eventIter.eventFilter->IsFilterEqual(i, filters[i]))
+					if (!eventIter.eventFilter->IsGenFilterEqual(i, filters[i]))
 						return kRetn_Continue;	// new event has sufficiently different filters, look for another event match.
 				}
 				return kRetn_Return; // event is already registered with the same filters.
@@ -229,10 +229,10 @@ public:
 			{
 				if (auto eventFilters = it->eventFilter)
 				{
-					auto const maxFilters = eventFilters->GetNumFilters();
+					auto const maxFilters = eventFilters->GetNumGenFilters();
 					for (int i = 0; i < maxFilters; i++)
 					{
-						if (!it->eventFilter->IsFilterEqual(i, filters[i]))
+						if (!it->eventFilter->IsGenFilterEqual(i, filters[i]))
 							goto NotFound;
 					}
 				}

--- a/JG/events/JohnnyEventPredefinitions.h
+++ b/JG/events/JohnnyEventPredefinitions.h
@@ -165,14 +165,11 @@ public:
 			kRetn_Continue = 1,
 			kRetn_Return = 2,
 		};
-
-		// TODO: Make this account for forms inside form-lists???
-		// todo: either store the unmodified GenFilters (pre-formlist and filtering)
-		// or... repeat those steps here somehow.
 		auto CheckFilterFunc = [&, this](BaseEventClass &eventIter) -> UInt8
 		{
 			if (script == eventIter.ScriptForEvent)
 			{
+				if (!num_max_filters) return kRetn_Return;	// filter-less event was already registered
 				if (!eventIter.eventFilter->GetNumFilters()) return kRetn_Continue;
 				for (int i = 0; i < num_max_filters; i++)
 				{

--- a/JG/events/JohnnyEventPredefinitions.h
+++ b/JG/events/JohnnyEventPredefinitions.h
@@ -65,7 +65,7 @@ public:
 
 
 template<typename _Filter>
-class EventInformation : BaseEventInformation
+class EventInformation : public BaseEventInformation
 {
 	using BaseEventInformation::BaseEventInformation; //steal the constructor
 	

--- a/JG/events/JohnnyEventPredefinitions.h
+++ b/JG/events/JohnnyEventPredefinitions.h
@@ -211,6 +211,11 @@ public:
 		FilterTypeSetArray arr { filter };
 		return RegisterEvent(script, arr);
 	}
+	bool virtual RegisterEvent(Script* script)
+	{
+		FilterTypeSetArray nullArr{};
+		return RegisterEvent(script, nullArr);
+	}
 	
 	void virtual RemoveEvent(Script* script, FilterTypeSetArray &filters)
 	{
@@ -238,6 +243,11 @@ public:
 	{
 		FilterTypeSetArray arr { filter };
 		RemoveEvent(script, arr);
+	}
+	void virtual RemoveEvent(Script* script)
+	{
+		FilterTypeSetArray nullArr{};
+		RemoveEvent(script, nullArr);
 	}
 	
 	void virtual AddQueuedEvents()

--- a/JG/events/JohnnyEventPredefinitions.h
+++ b/JG/events/JohnnyEventPredefinitions.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <shared_mutex>
-#include "events/CustomEventFilters.h"
+#include "events/EventFilteringInterface.h"
 #include <unordered_set>
 
 

--- a/JG/events/JohnnyEventPredefinitions.h
+++ b/JG/events/JohnnyEventPredefinitions.h
@@ -164,9 +164,8 @@ public:
 
 		enum CheckFilterFunc_ReturnValues
 		{
-			kRetn_Break = 0,
-			kRetn_Continue = 1,
-			kRetn_Return = 2,
+			kRetn_Continue = 0,
+			kRetn_Return = 1,
 		};
 		auto CheckFilterFunc = [&, this](BaseEventClass &eventIter) -> UInt8
 		{
@@ -177,7 +176,7 @@ public:
 				for (int i = 0; i < num_max_filters; i++)
 				{
 					if (!eventIter.eventFilter->IsFilterEqual(i, filters[i]))
-						return kRetn_Break;
+						return kRetn_Continue;	// new event has sufficiently different filters, look for another event match.
 				}
 				return kRetn_Return; // event is already registered with the same filters.
 			}
@@ -187,7 +186,6 @@ public:
 		for (auto &callbackIter: event_callbacks)
 		{
 			auto const check = CheckFilterFunc(callbackIter);
-			if (check == kRetn_Break) break;
 			if (check == kRetn_Return) return false;
 		}
 		
@@ -195,7 +193,6 @@ public:
 		for (auto &eventQueueIter : event_queue_add)
 		{
 			auto const check = CheckFilterFunc(eventQueueIter);
-			if (check == kRetn_Break) break;
 			if (check == kRetn_Return) return false;
 		}
 		rLock.unlock();

--- a/JG/events/JohnnyEventPredefinitions.h
+++ b/JG/events/JohnnyEventPredefinitions.h
@@ -1,6 +1,8 @@
 #pragma once
-#include "events/EventFilteringInterface.h"
+#include <shared_mutex>
+#include "events/CustomEventFilters.h"
 #include <unordered_set>
+
 
 bool (*FunctionCallScript)(Script* funcScript, TESObjectREFR* callingObj, TESObjectREFR* container, NVSEArrayElement* result, UInt8 numArgs, ...);
 NVSEArrayElement EventResultPtr;

--- a/JG/events/JohnnyEvents.h
+++ b/JG/events/JohnnyEvents.h
@@ -1,4 +1,6 @@
 #pragma once
+#include "EventFilterStructs.h"
+
 DEFINE_COMMAND_ALT_PLUGIN(SetJohnnyOnDyingEventHandler, SetOnDyingEventHandler, , 0, 4, kParams_Event_OneForm);
 DEFINE_COMMAND_ALT_PLUGIN(SetJohnnyOnStartQuestEventHandler, SetOnStartQuestEventHandler, , 0, 4, kParams_Event_OneForm);
 DEFINE_COMMAND_ALT_PLUGIN(SetJohnnyOnStopQuestEventHandler, SetOnStopQuestEventHandler, , 0, 4, kParams_Event_OneForm);
@@ -64,6 +66,7 @@ void __stdcall handleDyingEvent(Actor* thisObj) {
 		}
 	}
 }
+
 UInt32 __fastcall handleCrosshairEvent(TESObjectREFR* crosshairRef) {
 	if (crosshairRef) {
 		for (auto const& callback : OnCrosshairHandler->event_callbacks) {
@@ -76,6 +79,7 @@ UInt32 __fastcall handleCrosshairEvent(TESObjectREFR* crosshairRef) {
 	}
 	return ThisStdCall<UInt32>(0x579280, crosshairRef);
 }
+
 bool __fastcall HandleLimbGoneEvent(ExtraDismemberedLimbs* xData, Actor* actor, byte dummy, int limb, byte isExplode) {
 	for (auto const& callback : OnLimbGoneHandler->event_callbacks) {
 		if (reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsInFilter(0, actor) &&
@@ -122,6 +126,7 @@ void __cdecl handleSettingsUpdate() {
 		FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnSettingsUpdateHandler->num_max_args);
 	}
 }
+
 ExtraDataList* __fastcall HandleSeenDataUpdateEvent(TESObjectCELL* cell) {
 	for (auto const& callback : OnSeenDataUpdateHandler->event_callbacks) {
 		if (reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsBaseInFilter(0, cell)) // 0 is filter one, and we only use an argument so we don't need to check further filters
@@ -131,6 +136,7 @@ ExtraDataList* __fastcall HandleSeenDataUpdateEvent(TESObjectCELL* cell) {
 	}
 	return &cell->extraDataList;
 }
+
 UInt32 __fastcall HandleChallengeCompleteEvent(TESChallenge* challenge) {
 	for (auto const& callback : OnChallengeCompleteHandler->event_callbacks) {
 		if (reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsBaseInFilter(0, challenge)) // 0 is filter one, and we only use an argument so we don't need to check further filters
@@ -159,6 +165,7 @@ UInt32 __fastcall handlerRenderMenuEvent(void* ECX, void* edx, int arg1, int arg
 	}
 	return ThisStdCall<UInt32>(0x08706B0, ECX, arg1, arg2, arg3);
 }
+
 __declspec(naked) void OnCrosshairEventAsm() {
 	static const UInt32 retnAddr = 0x775A69;
 	__asm {
@@ -169,6 +176,7 @@ __declspec(naked) void OnCrosshairEventAsm() {
 		jmp retnAddr
 	}
 }
+
 __declspec (naked) void OnDyingEventAsm()
 {
 	static const UInt32 checkProtect = 0xEC408C;
@@ -203,6 +211,7 @@ __declspec (naked) void OnQuestStartStopEventAsm()
 		ret 4
 	}
 }
+
 bool Cmd_SetJohnnyOnLimbGoneEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
@@ -465,7 +474,9 @@ void HandleEventHooks()
 	OnSettingsUpdateHandler = JGCreateEvent("OnSettingsUpdate", 0, 0);
 	OnAddPerkHandler = JGCreateEvent("OnAddPerk", 3, 1);
 	OnRemovePerkHandler = JGCreateEvent("OnRemovePerk", 1, 1);
+	
 	FunctionCallScript = g_scriptInterface->CallFunction;
+	
 	WriteRelCall(0x55678A, (UINT)HandleSeenDataUpdateEvent);
 	WriteRelCall(0x557053, (UINT)HandleSeenDataUpdateEvent);
 	WriteRelJump(0x89F4A4, (UINT)OnDyingEventAsm);

--- a/JG/events/JohnnyEvents.h
+++ b/JG/events/JohnnyEvents.h
@@ -92,7 +92,7 @@ bool __fastcall HandleLimbGoneEvent(ExtraDismemberedLimbs* xData, Actor* actor, 
 	return ThisStdCall_B(0x430410, xData, actor, limb, isExplode);
 }
 void __fastcall handleQuestStartStop(TESQuest* Quest, bool IsStarted) {
-	EventInformation* thisEvent = IsStarted ? OnStartQuestHandler : OnStopQuestHandler;
+	auto thisEvent = IsStarted ? OnStartQuestHandler : OnStopQuestHandler;
 	for (auto const& callback : thisEvent->event_callbacks) {
 		if (reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsBaseInFilter(0, Quest)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{

--- a/JG/events/JohnnyEvents.h
+++ b/JG/events/JohnnyEvents.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "CustomEventFilters.h"
 #include "EventFilterStructs.h"
 
 DEFINE_COMMAND_ALT_PLUGIN(SetJohnnyOnDyingEventHandler, SetOnDyingEventHandler, , 0, 4, kParams_Event_OneForm);

--- a/JG/events/JohnnyEvents.h
+++ b/JG/events/JohnnyEvents.h
@@ -16,20 +16,20 @@ DEFINE_COMMAND_ALT_PLUGIN(SetJohnnyOnAddPerkEventHandler, SetOnAddPerkEventHandl
 DEFINE_COMMAND_ALT_PLUGIN(SetJohnnyOnRemovePerkEventHandler, SetOnRemovePerkEventHandler, , 0, 4, kParams_Event_OneForm);
 DEFINE_COMMAND_ALT_PLUGIN(SetJohnnyOnRenderUpdateEventHandler, SetOnRenderUpdateEventHandler, , 0, 3, kParams_Event);
 
-EventInformation* OnDyingHandler;
-EventInformation* OnStartQuestHandler;
-EventInformation* OnStopQuestHandler;
-EventInformation* OnFailQuestHandler;
-EventInformation* OnCompleteQuestHandler;
-EventInformation* OnSeenDataUpdateHandler;
-EventInformation* OnLimbGoneHandler;
-EventInformation* OnChallengeCompleteHandler;
-EventInformation* OnCrosshairHandler;
-EventInformation* OnSettingsUpdateHandler;
-EventInformation* OnAddPerkHandler;
-EventInformation* OnRemovePerkHandler;
-EventInformation* OnRenderGameModeUpdateHandler;
-EventInformation* OnRenderRenderedMenuUpdateHandler;
+EventInformation<EventFilter_OneForm>* OnDyingHandler;
+EventInformation<EventFilter_OneForm>* OnStartQuestHandler;
+EventInformation<EventFilter_OneForm>* OnStopQuestHandler;
+EventInformation<EventFilter_OneForm>* OnFailQuestHandler;
+EventInformation<EventFilter_OneForm>* OnCompleteQuestHandler;
+EventInformation<EventFilter_OneForm>* OnSeenDataUpdateHandler;
+EventInformation<EventFilter_OneForm_OneInt>* OnLimbGoneHandler;
+EventInformation<EventFilter_OneForm>* OnChallengeCompleteHandler;
+EventInformation<EventFilter_OneForm_OneInt>* OnCrosshairHandler;
+EventInformation<EventFilter_Null>* OnSettingsUpdateHandler;
+EventInformation<EventFilter_OneForm>* OnAddPerkHandler;
+EventInformation<EventFilter_OneForm>* OnRemovePerkHandler;
+EventInformation<EventFilter_Null>* OnRenderGameModeUpdateHandler;
+EventInformation<EventFilter_Null>* OnRenderRenderedMenuUpdateHandler;
 
 void __fastcall handleRemovePerkEvent(Actor* actor, int EDX, BGSPerk* perk, bool isTeammatePerk)
 {
@@ -463,18 +463,18 @@ bool Cmd_SetJohnnyOnRenderUpdateEventHandler_Execute(COMMAND_ARGS)
 
 void HandleEventHooks()
 {
-	OnDyingHandler = JGCreateEvent("OnDying", 1, 1);
-	OnStartQuestHandler = JGCreateEvent("OnStartQuest", 1, 1);
-	OnStopQuestHandler = JGCreateEvent("OnStopQuest", 1, 1);
-	OnSeenDataUpdateHandler = JGCreateEvent("OnSeenDataUpdate", 1, 1);
-	OnLimbGoneHandler = JGCreateEvent("OnLimbGone", 2, 2);
-	OnChallengeCompleteHandler = JGCreateEvent("OnChallengeComplete", 1, 1);
-	OnCrosshairHandler = JGCreateEvent("OnCrosshair", 1, 2);
-	OnCompleteQuestHandler = JGCreateEvent("OnCompleteQuest", 1, 1);
-	OnFailQuestHandler = JGCreateEvent("OnFailQuest", 1, 1);
-	OnSettingsUpdateHandler = JGCreateEvent("OnSettingsUpdate", 0, 0);
-	OnAddPerkHandler = JGCreateEvent("OnAddPerk", 3, 1);
-	OnRemovePerkHandler = JGCreateEvent("OnRemovePerk", 1, 1);
+	OnDyingHandler = JGCreateEvent("OnDying", 1);
+	OnStartQuestHandler = JGCreateEvent("OnStartQuest", 1);
+	OnStopQuestHandler = JGCreateEvent("OnStopQuest", 1);
+	OnSeenDataUpdateHandler = JGCreateEvent("OnSeenDataUpdate", 1);
+	OnLimbGoneHandler = JGCreateEvent("OnLimbGone", 2);
+	OnChallengeCompleteHandler = JGCreateEvent("OnChallengeComplete", 1);
+	OnCrosshairHandler = JGCreateEvent("OnCrosshair", 1);
+	OnCompleteQuestHandler = JGCreateEvent("OnCompleteQuest", 1);
+	OnFailQuestHandler = JGCreateEvent("OnFailQuest", 1);
+	OnSettingsUpdateHandler = JGCreateEvent("OnSettingsUpdate", 0);
+	OnAddPerkHandler = JGCreateEvent("OnAddPerk", 3);
+	OnRemovePerkHandler = JGCreateEvent("OnRemovePerk", 1);
 	
 	FunctionCallScript = g_scriptInterface->CallFunction;
 	
@@ -498,9 +498,9 @@ void HandleEventHooks()
 
 
 	//testing
-	OnRenderGameModeUpdateHandler = JGCreateEvent("OnRenderGameModeUpdateHandler", 0, 0);
+	OnRenderGameModeUpdateHandler = JGCreateEvent("OnRenderGameModeUpdateHandler", 0);
 	WriteRelCall(0x870244, (uintptr_t)handlerRenderGameEvent);
-	OnRenderRenderedMenuUpdateHandler = JGCreateEvent("OnRenderRenderedMenuUpdateHandler", 0, 0);
+	OnRenderRenderedMenuUpdateHandler = JGCreateEvent<EventFilter_Null>("OnRenderRenderedMenuUpdateHandler", 0);
 	WriteRelCall(0x8702A9, (uintptr_t)handlerRenderMenuEvent);
 
 }

--- a/JG/events/JohnnyEvents.h
+++ b/JG/events/JohnnyEvents.h
@@ -36,7 +36,7 @@ void __fastcall handleRemovePerkEvent(Actor* actor, int EDX, BGSPerk* perk, bool
 	{
 		if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, perk)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
-			FunctionCallScript(callback.ScriptForEvent, actor, 0, &EventResultPtr, OnRemovePerkHandler->numMaxArgs, perk);
+			FunctionCallScript(callback.ScriptForEvent, actor, 0, &EventResultPtr, OnRemovePerkHandler->num_max_args, perk);
 		}
 	}
 	actor->RemovePerk(perk, isTeammatePerk);
@@ -48,7 +48,7 @@ void __fastcall handleAddPerkEvent(Actor* actor, int EDX, BGSPerk* perk, UInt8 n
 	{
 		if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, perk)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
-			FunctionCallScript(callback.ScriptForEvent, actor, 0, &EventResultPtr, OnAddPerkHandler->numMaxArgs, perk, newRank - 1, newRank);
+			FunctionCallScript(callback.ScriptForEvent, actor, 0, &EventResultPtr, OnAddPerkHandler->num_max_args, perk, newRank - 1, newRank);
 		}
 	}
 	actor->SetPerkRank(perk, newRank, isTeammatePerk);
@@ -59,7 +59,7 @@ void __stdcall handleDyingEvent(Actor* thisObj) {
 		for (auto const& callback : OnDyingHandler->EventCallbacks) {
 			if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, thisObj)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 			{
-				FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnDyingHandler->numMaxArgs, thisObj);
+				FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnDyingHandler->num_max_args, thisObj);
 			}
 		}
 	}
@@ -70,7 +70,7 @@ UInt32 __fastcall handleCrosshairEvent(TESObjectREFR* crosshairRef) {
 			JohnnyEventFiltersOneFormOneInt* filter = reinterpret_cast<JohnnyEventFiltersOneFormOneInt*>(callback.eventFilter);
 			if ((filter->IsInFilter(0, crosshairRef->refID) || filter->IsInFilter(0, crosshairRef->baseForm->refID)) && filter->IsInFilter(1, crosshairRef->baseForm->typeID))
 			{
-				FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnCrosshairHandler->numMaxArgs, crosshairRef);
+				FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnCrosshairHandler->num_max_args, crosshairRef);
 			}
 		}
 	}
@@ -81,7 +81,7 @@ bool __fastcall HandleLimbGoneEvent(ExtraDismemberedLimbs* xData, Actor* actor, 
 		if (reinterpret_cast<JohnnyEventFiltersOneFormOneInt*>(callback.eventFilter)->IsInFilter(0, actor->refID) &&
 			reinterpret_cast<JohnnyEventFiltersOneFormOneInt*>(callback.eventFilter)->IsInFilter(1, limb)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
-			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnLimbGoneHandler->numMaxArgs, actor, limb);
+			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnLimbGoneHandler->num_max_args, actor, limb);
 		}
 	}
 	return ThisStdCall_B(0x430410, xData, actor, limb, isExplode);
@@ -91,7 +91,7 @@ void __fastcall handleQuestStartStop(TESQuest* Quest, bool IsStarted) {
 	for (auto const& callback : thisEvent->EventCallbacks) {
 		if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, Quest)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
-			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, thisEvent->numMaxArgs, Quest);
+			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, thisEvent->num_max_args, Quest);
 		}
 	}
 }
@@ -100,7 +100,7 @@ void __cdecl handleQuestComplete(TESQuest* Quest) {
 	for (auto const& callback : OnCompleteQuestHandler->EventCallbacks) {
 		if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, Quest)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
-			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnCompleteQuestHandler->numMaxArgs, Quest);
+			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnCompleteQuestHandler->num_max_args, Quest);
 		}
 	}
 	CdeclCall(0x77A480, Quest);
@@ -110,7 +110,7 @@ void __cdecl handleQuestFail(TESQuest* Quest) {
 	for (auto const& callback : OnFailQuestHandler->EventCallbacks) {
 		if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, Quest)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
-			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnFailQuestHandler->numMaxArgs, Quest);
+			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnFailQuestHandler->num_max_args, Quest);
 		}
 	}
 	CdeclCall(0x77A480, Quest);
@@ -119,14 +119,14 @@ void __cdecl handleQuestFail(TESQuest* Quest) {
 void __cdecl handleSettingsUpdate() {
 	CdeclCall(0x7D6D70);
 	for (auto const& callback : OnSettingsUpdateHandler->EventCallbacks) {
-		FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnSettingsUpdateHandler->numMaxArgs);
+		FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnSettingsUpdateHandler->num_max_args);
 	}
 }
 ExtraDataList* __fastcall HandleSeenDataUpdateEvent(TESObjectCELL* cell) {
 	for (auto const& callback : OnSeenDataUpdateHandler->EventCallbacks) {
 		if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, cell)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
-			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnSeenDataUpdateHandler->numMaxArgs, cell);
+			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnSeenDataUpdateHandler->num_max_args, cell);
 		}
 	}
 	return &cell->extraDataList;
@@ -135,7 +135,7 @@ UInt32 __fastcall HandleChallengeCompleteEvent(TESChallenge* challenge) {
 	for (auto const& callback : OnChallengeCompleteHandler->EventCallbacks) {
 		if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, challenge)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
-			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnChallengeCompleteHandler->numMaxArgs, challenge);
+			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnChallengeCompleteHandler->num_max_args, challenge);
 		}
 	}
 	return challenge->data.type;
@@ -145,7 +145,7 @@ UInt32 __fastcall HandleChallengeCompleteEvent(TESChallenge* challenge) {
 UInt32 __fastcall handlerRenderGameEvent(void* ECX, void* edx, int arg1, int arg2, int arg3) {
 	for (auto const& callback : OnRenderGameModeUpdateHandler->EventCallbacks) {
 
-			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnRenderGameModeUpdateHandler->numMaxArgs);
+			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnRenderGameModeUpdateHandler->num_max_args);
 
 	}
 	return ThisStdCall<UInt32>(0x08706B0, ECX, arg1, arg2, arg3);
@@ -154,7 +154,7 @@ UInt32 __fastcall handlerRenderGameEvent(void* ECX, void* edx, int arg1, int arg
 UInt32 __fastcall handlerRenderMenuEvent(void* ECX, void* edx, int arg1, int arg2, int arg3) {
 	for (auto const& callback : OnRenderRenderedMenuUpdateHandler->EventCallbacks) {
 
-		FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnRenderRenderedMenuUpdateHandler->numMaxArgs);
+		FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnRenderRenderedMenuUpdateHandler->num_max_args);
 
 	}
 	return ThisStdCall<UInt32>(0x08706B0, ECX, arg1, arg2, arg3);
@@ -409,15 +409,17 @@ bool Cmd_SetJohnnyOnFailQuestEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
 	Script* script = NULL;
-	TESForm* filter[1] = { NULL };
+	TESForm* filter;
 	UInt32 flags = 0;
-	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter[0]) || NOT_TYPE(script, Script))) return true;
+	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter) || NOT_TYPE(script, Script))) return true;
 	{
+		FormSet formSet { filter };
+		FilterTypeSets genericSet = formSet;
 		if (OnFailQuestHandler)
 		{
 			if (setOrRemove)
-				OnFailQuestHandler->RegisterEvent(script, (void**)filter);
-			else OnFailQuestHandler->RemoveEvent(script, (void**)filter);
+				OnFailQuestHandler->RegisterEvent(script, genericSet);
+			else OnFailQuestHandler->RemoveEvent(script, genericSet);
 
 		}
 		return true;
@@ -435,19 +437,20 @@ bool Cmd_SetJohnnyOnRenderUpdateEventHandler_Execute(COMMAND_ARGS)
 	};
 	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags) || NOT_TYPE(script, Script))) return true;
 	{
+		FilterTypeSetArray nullArr;
 		if (!(flags & kDoNotFireInGameMode) && OnRenderGameModeUpdateHandler)
 		{
 			if (setOrRemove)
-				OnRenderGameModeUpdateHandler->RegisterEvent(script, NULL);
-			else OnRenderGameModeUpdateHandler->RemoveEvent(script, NULL);
+				OnRenderGameModeUpdateHandler->RegisterEvent(script, nullArr);
+			else OnRenderGameModeUpdateHandler->RemoveEvent(script, nullArr);
 
 		}
 
 		if (!(flags & kDoNotFireInRenderMenu) && OnRenderRenderedMenuUpdateHandler)
 		{
 			if (setOrRemove)
-				OnRenderRenderedMenuUpdateHandler->RegisterEvent(script, NULL);
-			else OnRenderRenderedMenuUpdateHandler->RemoveEvent(script, NULL);
+				OnRenderRenderedMenuUpdateHandler->RegisterEvent(script, nullArr);
+			else OnRenderRenderedMenuUpdateHandler->RemoveEvent(script, nullArr);
 
 		}
 		return true;
@@ -456,18 +459,18 @@ bool Cmd_SetJohnnyOnRenderUpdateEventHandler_Execute(COMMAND_ARGS)
 
 void HandleEventHooks()
 {
-	OnDyingHandler = JGCreateEvent("OnDying", 1, 1, NULL);
-	OnStartQuestHandler = JGCreateEvent("OnStartQuest", 1, 1, NULL);
-	OnStopQuestHandler = JGCreateEvent("OnStopQuest", 1, 1, NULL);
-	OnSeenDataUpdateHandler = JGCreateEvent("OnSeenDataUpdate", 1, 1, NULL);
-	OnLimbGoneHandler = JGCreateEvent("OnLimbGone", 2, 2, CreateOneFormOneIntFilter);
-	OnChallengeCompleteHandler = JGCreateEvent("OnChallengeComplete", 1, 1, NULL);
-	OnCrosshairHandler = JGCreateEvent("OnCrosshair", 1, 2, CreateOneFormOneIntFilter);
-	OnCompleteQuestHandler = JGCreateEvent("OnCompleteQuest", 1, 1, NULL);
-	OnFailQuestHandler = JGCreateEvent("OnFailQuest", 1, 1, NULL);
-	OnSettingsUpdateHandler = JGCreateEvent("OnSettingsUpdate", 0, 0, NULL);
-	OnAddPerkHandler = JGCreateEvent("OnAddPerk", 3, 1, NULL);
-	OnRemovePerkHandler = JGCreateEvent("OnRemovePerk", 1, 1, NULL);
+	OnDyingHandler = JGCreateEvent("OnDying", 1, 1);
+	OnStartQuestHandler = JGCreateEvent("OnStartQuest", 1, 1);
+	OnStopQuestHandler = JGCreateEvent("OnStopQuest", 1, 1);
+	OnSeenDataUpdateHandler = JGCreateEvent("OnSeenDataUpdate", 1, 1);
+	OnLimbGoneHandler = JGCreateEvent("OnLimbGone", 2, 2);
+	OnChallengeCompleteHandler = JGCreateEvent("OnChallengeComplete", 1, 1);
+	OnCrosshairHandler = JGCreateEvent("OnCrosshair", 1, 2);
+	OnCompleteQuestHandler = JGCreateEvent("OnCompleteQuest", 1, 1);
+	OnFailQuestHandler = JGCreateEvent("OnFailQuest", 1, 1);
+	OnSettingsUpdateHandler = JGCreateEvent("OnSettingsUpdate", 0, 0);
+	OnAddPerkHandler = JGCreateEvent("OnAddPerk", 3, 1);
+	OnRemovePerkHandler = JGCreateEvent("OnRemovePerk", 1, 1);
 	FunctionCallScript = g_scriptInterface->CallFunction;
 	WriteRelCall(0x55678A, (UINT)HandleSeenDataUpdateEvent);
 	WriteRelCall(0x557053, (UINT)HandleSeenDataUpdateEvent);

--- a/JG/events/JohnnyEvents.h
+++ b/JG/events/JohnnyEvents.h
@@ -79,7 +79,7 @@ UInt32 __fastcall handleCrosshairEvent(TESObjectREFR* crosshairRef) {
 bool __fastcall HandleLimbGoneEvent(ExtraDismemberedLimbs* xData, Actor* actor, byte dummy, int limb, byte isExplode) {
 	for (auto const& callback : OnLimbGoneHandler->event_callbacks) {
 		if (reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsInFilter(0, actor) &&
-			reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsInFilter(1, limb)) // 0 is filter one, and we only use an argument so we don't need to check further filters
+			reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsInFilter(1, limb))
 		{
 			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnLimbGoneHandler->num_max_args, actor, limb);
 		}

--- a/JG/events/JohnnyEvents.h
+++ b/JG/events/JohnnyEvents.h
@@ -223,10 +223,9 @@ bool Cmd_SetJohnnyOnLimbGoneEventHandler_Execute(COMMAND_ARGS)
 	{
 		if (OnLimbGoneHandler)
 		{
-			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnLimbGoneHandler->RegisterEvent(script, filterArr);
-			else OnLimbGoneHandler->RemoveEvent(script, filterArr);
+				OnLimbGoneHandler->RegisterEvent(script, filter);
+			else OnLimbGoneHandler->RemoveEvent(script, filter);
 		}
 		return true;
 	}
@@ -235,14 +234,15 @@ bool Cmd_SetJohnnyOnSettingsUpdateEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
 	Script* script = nullptr;
+	EventFilter_Null filter;
 	UInt32 flags = 0;
 	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags) || NOT_TYPE(script, Script))) return true;
 	{
 		if (OnSettingsUpdateHandler)
 		{
 			if (setOrRemove)
-				OnSettingsUpdateHandler->RegisterEvent(script);
-			else OnSettingsUpdateHandler->RemoveEvent(script);
+				OnSettingsUpdateHandler->RegisterEvent(script, filter);
+			else OnSettingsUpdateHandler->RemoveEvent(script, filter);
 		}
 		return true;
 	}
@@ -257,10 +257,9 @@ bool Cmd_SetJohnnyOnCrosshairEventHandler_Execute(COMMAND_ARGS)
 	{
 		if (OnCrosshairHandler)
 		{
-			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnCrosshairHandler->RegisterEvent(script, filterArr);
-			else OnCrosshairHandler->RemoveEvent(script, filterArr);
+				OnCrosshairHandler->RegisterEvent(script, filter);
+			else OnCrosshairHandler->RemoveEvent(script, filter);
 		}
 		return true;
 	}
@@ -275,10 +274,9 @@ bool Cmd_SetJohnnyOnRemovePerkEventHandler_Execute(COMMAND_ARGS)
 	{
 		if (OnRemovePerkHandler)
 		{
-			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnRemovePerkHandler->RegisterEvent(script, filterArr);
-			else OnRemovePerkHandler->RemoveEvent(script, filterArr);
+				OnRemovePerkHandler->RegisterEvent(script, filter);
+			else OnRemovePerkHandler->RemoveEvent(script, filter);
 		}
 		return true;
 	}
@@ -293,10 +291,9 @@ bool Cmd_SetJohnnyOnAddPerkEventHandler_Execute(COMMAND_ARGS)
 	{
 		if (OnAddPerkHandler)
 		{
-			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnAddPerkHandler->RegisterEvent(script, filterArr);
-			else OnAddPerkHandler->RemoveEvent(script, filterArr);
+				OnAddPerkHandler->RegisterEvent(script, filter);
+			else OnAddPerkHandler->RemoveEvent(script, filter);
 		}
 		return true;
 	}
@@ -311,10 +308,9 @@ bool Cmd_SetJohnnyOnChallengeCompleteEventHandler_Execute(COMMAND_ARGS)
 	{
 		if (OnChallengeCompleteHandler)
 		{
-			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnChallengeCompleteHandler->RegisterEvent(script, filterArr);
-			else OnChallengeCompleteHandler->RemoveEvent(script, filterArr);
+				OnChallengeCompleteHandler->RegisterEvent(script, filter);
+			else OnChallengeCompleteHandler->RemoveEvent(script, filter);
 		}
 		return true;
 	}
@@ -329,10 +325,9 @@ bool Cmd_SetJohnnySeenDataEventHandler_Execute(COMMAND_ARGS)
 	{
 		if (OnSeenDataUpdateHandler)
 		{
-			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnSeenDataUpdateHandler->RegisterEvent(script, filterArr);
-			else OnSeenDataUpdateHandler->RemoveEvent(script, filterArr);
+				OnSeenDataUpdateHandler->RegisterEvent(script, filter);
+			else OnSeenDataUpdateHandler->RemoveEvent(script, filter);
 		}
 		return true;
 	}
@@ -347,10 +342,9 @@ bool Cmd_SetJohnnyOnDyingEventHandler_Execute(COMMAND_ARGS)
 	{
 		if (OnDyingHandler)
 		{
-			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnDyingHandler->RegisterEvent(script, filterArr);
-			else OnDyingHandler->RemoveEvent(script, filterArr);
+				OnDyingHandler->RegisterEvent(script, filter);
+			else OnDyingHandler->RemoveEvent(script, filter);
 		}
 		return true;
 	}
@@ -366,15 +360,13 @@ bool Cmd_SetJohnnyOnStartQuestEventHandler_Execute(COMMAND_ARGS)
 	{
 		if (OnStartQuestHandler)
 		{
-			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnStartQuestHandler->RegisterEvent(script, filterArr);
-			else OnStartQuestHandler->RemoveEvent(script, filterArr);
+				OnStartQuestHandler->RegisterEvent(script, filter);
+			else OnStartQuestHandler->RemoveEvent(script, filter);
 		}
 		return true;
 	}
 }
-
 
 bool Cmd_SetJohnnyOnStopQuestEventHandler_Execute(COMMAND_ARGS)
 {
@@ -386,10 +378,9 @@ bool Cmd_SetJohnnyOnStopQuestEventHandler_Execute(COMMAND_ARGS)
 	{
 		if (OnStopQuestHandler)
 		{
-			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnStopQuestHandler->RegisterEvent(script, filterArr);
-			else OnStopQuestHandler->RemoveEvent(script, filterArr);
+				OnStopQuestHandler->RegisterEvent(script, filter);
+			else OnStopQuestHandler->RemoveEvent(script, filter);
 		}
 		return true;
 	}
@@ -405,10 +396,9 @@ bool Cmd_SetJohnnyOnCompleteQuestEventHandler_Execute(COMMAND_ARGS)
 	{
 		if (OnCompleteQuestHandler)
 		{
-			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnCompleteQuestHandler->RegisterEvent(script, filterArr);
-			else OnCompleteQuestHandler->RemoveEvent(script, filterArr);
+				OnCompleteQuestHandler->RegisterEvent(script, filter);
+			else OnCompleteQuestHandler->RemoveEvent(script, filter);
 		}
 		return true;
 	}
@@ -424,10 +414,9 @@ bool Cmd_SetJohnnyOnFailQuestEventHandler_Execute(COMMAND_ARGS)
 	{
 		if (OnFailQuestHandler)
 		{
-			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnFailQuestHandler->RegisterEvent(script, filterArr);
-			else OnFailQuestHandler->RemoveEvent(script, filterArr);
+				OnFailQuestHandler->RegisterEvent(script, filter);
+			else OnFailQuestHandler->RemoveEvent(script, filter);
 		}
 		return true;
 	}
@@ -438,6 +427,7 @@ bool Cmd_SetJohnnyOnRenderUpdateEventHandler_Execute(COMMAND_ARGS)
 	UInt32 setOrRemove = 0;
 	Script* script = NULL;
 	UInt32 flags = 0;
+	EventFilter_Null filter;
 	enum EnumFlags {
 		kDoNotFireInRenderMenu = 1 << 0,
 		kDoNotFireInGameMode = 1 << 1,
@@ -447,15 +437,15 @@ bool Cmd_SetJohnnyOnRenderUpdateEventHandler_Execute(COMMAND_ARGS)
 		if (!(flags & kDoNotFireInGameMode) && OnRenderGameModeUpdateHandler)
 		{
 			if (setOrRemove)
-				OnRenderGameModeUpdateHandler->RegisterEvent(script);
-			else OnRenderGameModeUpdateHandler->RemoveEvent(script);
+				OnRenderGameModeUpdateHandler->RegisterEvent(script, filter);
+			else OnRenderGameModeUpdateHandler->RemoveEvent(script, filter);
 		}
 
 		if (!(flags & kDoNotFireInRenderMenu) && OnRenderRenderedMenuUpdateHandler)
 		{
 			if (setOrRemove)
-				OnRenderRenderedMenuUpdateHandler->RegisterEvent(script);
-			else OnRenderRenderedMenuUpdateHandler->RemoveEvent(script);
+				OnRenderRenderedMenuUpdateHandler->RegisterEvent(script, filter);
+			else OnRenderRenderedMenuUpdateHandler->RemoveEvent(script, filter);
 		}
 		return true;
 	}
@@ -463,18 +453,19 @@ bool Cmd_SetJohnnyOnRenderUpdateEventHandler_Execute(COMMAND_ARGS)
 
 void HandleEventHooks()
 {
-	OnDyingHandler = JGCreateEvent("OnDying", 1);
-	OnStartQuestHandler = JGCreateEvent("OnStartQuest", 1);
-	OnStopQuestHandler = JGCreateEvent("OnStopQuest", 1);
-	OnSeenDataUpdateHandler = JGCreateEvent("OnSeenDataUpdate", 1);
-	OnLimbGoneHandler = JGCreateEvent("OnLimbGone", 2);
-	OnChallengeCompleteHandler = JGCreateEvent("OnChallengeComplete", 1);
-	OnCrosshairHandler = JGCreateEvent("OnCrosshair", 1);
-	OnCompleteQuestHandler = JGCreateEvent("OnCompleteQuest", 1);
-	OnFailQuestHandler = JGCreateEvent("OnFailQuest", 1);
-	OnSettingsUpdateHandler = JGCreateEvent("OnSettingsUpdate", 0);
-	OnAddPerkHandler = JGCreateEvent("OnAddPerk", 3);
-	OnRemovePerkHandler = JGCreateEvent("OnRemovePerk", 1);
+	//todo: move to C++20 and use `using enum` for the BaseEvenInfo flag enum. 
+	OnDyingHandler = JGCreateEvent<EventFilter_OneForm>("OnDying", 1, (BaseEventInformation::eFlag_FlushOnLoad));
+	OnStartQuestHandler = JGCreateEvent<EventFilter_OneForm>("OnStartQuest", 1);
+	OnStopQuestHandler = JGCreateEvent<EventFilter_OneForm>("OnStopQuest", 1);
+	OnSeenDataUpdateHandler = JGCreateEvent<EventFilter_OneForm>("OnSeenDataUpdate", 1);
+	OnLimbGoneHandler = JGCreateEvent<EventFilter_OneForm_OneInt>("OnLimbGone", 2, (BaseEventInformation::eFlag_FlushOnLoad));
+	OnChallengeCompleteHandler = JGCreateEvent<EventFilter_OneForm>("OnChallengeComplete", 1);
+	OnCrosshairHandler = JGCreateEvent<EventFilter_OneForm_OneInt>("OnCrosshair", 1, (BaseEventInformation::eFlag_FlushOnLoad));
+	OnCompleteQuestHandler = JGCreateEvent<EventFilter_OneForm>("OnCompleteQuest", 1);
+	OnFailQuestHandler = JGCreateEvent<EventFilter_OneForm>("OnFailQuest", 1);
+	OnSettingsUpdateHandler = JGCreateEvent<EventFilter_Null>("OnSettingsUpdate", 0);
+	OnAddPerkHandler = JGCreateEvent<EventFilter_OneForm>("OnAddPerk", 3);
+	OnRemovePerkHandler = JGCreateEvent<EventFilter_OneForm>("OnRemovePerk", 1);
 	
 	FunctionCallScript = g_scriptInterface->CallFunction;
 	
@@ -496,9 +487,8 @@ void HandleEventHooks()
 	SafeWriteBuf(0x5D4F8E, "\x0F\x1F\x00", 3);
 	SafeWrite8(0x60CA29, 0xCC);
 
-
 	//testing
-	OnRenderGameModeUpdateHandler = JGCreateEvent("OnRenderGameModeUpdateHandler", 0);
+	OnRenderGameModeUpdateHandler = JGCreateEvent<EventFilter_Null>("OnRenderGameModeUpdateHandler", 0);
 	WriteRelCall(0x870244, (uintptr_t)handlerRenderGameEvent);
 	OnRenderRenderedMenuUpdateHandler = JGCreateEvent<EventFilter_Null>("OnRenderRenderedMenuUpdateHandler", 0);
 	WriteRelCall(0x8702A9, (uintptr_t)handlerRenderMenuEvent);

--- a/JG/events/JohnnyEvents.h
+++ b/JG/events/JohnnyEvents.h
@@ -32,9 +32,9 @@ void __fastcall handleRemovePerkEvent(Actor* actor, int EDX, BGSPerk* perk, bool
 {
 	if (!actor->GetPerkRank(perk, isTeammatePerk))
 		return;
-	for (auto const& callback : OnRemovePerkHandler->EventCallbacks)
+	for (auto const& callback : OnRemovePerkHandler->event_callbacks)
 	{
-		if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, perk)) // 0 is filter one, and we only use an argument so we don't need to check further filters
+		if (reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsBaseInFilter(0, perk)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
 			FunctionCallScript(callback.ScriptForEvent, actor, 0, &EventResultPtr, OnRemovePerkHandler->num_max_args, perk);
 		}
@@ -44,9 +44,9 @@ void __fastcall handleRemovePerkEvent(Actor* actor, int EDX, BGSPerk* perk, bool
 
 void __fastcall handleAddPerkEvent(Actor* actor, int EDX, BGSPerk* perk, UInt8 newRank, bool isTeammatePerk)
 {
-	for (auto const& callback : OnAddPerkHandler->EventCallbacks)
+	for (auto const& callback : OnAddPerkHandler->event_callbacks)
 	{
-		if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, perk)) // 0 is filter one, and we only use an argument so we don't need to check further filters
+		if (reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsBaseInFilter(0, perk)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
 			FunctionCallScript(callback.ScriptForEvent, actor, 0, &EventResultPtr, OnAddPerkHandler->num_max_args, perk, newRank - 1, newRank);
 		}
@@ -56,8 +56,8 @@ void __fastcall handleAddPerkEvent(Actor* actor, int EDX, BGSPerk* perk, UInt8 n
 
 void __stdcall handleDyingEvent(Actor* thisObj) {
 	if (thisObj->IsActor() && thisObj->lifeState == 1 && (*thisObj->GetTheName() || thisObj == g_thePlayer)) {
-		for (auto const& callback : OnDyingHandler->EventCallbacks) {
-			if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, thisObj)) // 0 is filter one, and we only use an argument so we don't need to check further filters
+		for (auto const& callback : OnDyingHandler->event_callbacks) {
+			if (reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsBaseInFilter(0, thisObj)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 			{
 				FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnDyingHandler->num_max_args, thisObj);
 			}
@@ -66,9 +66,9 @@ void __stdcall handleDyingEvent(Actor* thisObj) {
 }
 UInt32 __fastcall handleCrosshairEvent(TESObjectREFR* crosshairRef) {
 	if (crosshairRef) {
-		for (auto const& callback : OnCrosshairHandler->EventCallbacks) {
-			JohnnyEventFiltersOneFormOneInt* filter = reinterpret_cast<JohnnyEventFiltersOneFormOneInt*>(callback.eventFilter);
-			if ((filter->IsInFilter(0, crosshairRef->refID) || filter->IsInFilter(0, crosshairRef->baseForm->refID)) && filter->IsInFilter(1, crosshairRef->baseForm->typeID))
+		for (auto const& callback : OnCrosshairHandler->event_callbacks) {
+			auto filter = reinterpret_cast<GenericEventFilters*>(callback.eventFilter);
+			if ((filter->IsInFilter(0, crosshairRef) || filter->IsBaseInFilter(0, crosshairRef)) && filter->IsInFilter(1, crosshairRef->baseForm->typeID))
 			{
 				FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnCrosshairHandler->num_max_args, crosshairRef);
 			}
@@ -77,9 +77,9 @@ UInt32 __fastcall handleCrosshairEvent(TESObjectREFR* crosshairRef) {
 	return ThisStdCall<UInt32>(0x579280, crosshairRef);
 }
 bool __fastcall HandleLimbGoneEvent(ExtraDismemberedLimbs* xData, Actor* actor, byte dummy, int limb, byte isExplode) {
-	for (auto const& callback : OnLimbGoneHandler->EventCallbacks) {
-		if (reinterpret_cast<JohnnyEventFiltersOneFormOneInt*>(callback.eventFilter)->IsInFilter(0, actor->refID) &&
-			reinterpret_cast<JohnnyEventFiltersOneFormOneInt*>(callback.eventFilter)->IsInFilter(1, limb)) // 0 is filter one, and we only use an argument so we don't need to check further filters
+	for (auto const& callback : OnLimbGoneHandler->event_callbacks) {
+		if (reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsInFilter(0, actor) &&
+			reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsInFilter(1, limb)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
 			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnLimbGoneHandler->num_max_args, actor, limb);
 		}
@@ -88,8 +88,8 @@ bool __fastcall HandleLimbGoneEvent(ExtraDismemberedLimbs* xData, Actor* actor, 
 }
 void __fastcall handleQuestStartStop(TESQuest* Quest, bool IsStarted) {
 	EventInformation* thisEvent = IsStarted ? OnStartQuestHandler : OnStopQuestHandler;
-	for (auto const& callback : thisEvent->EventCallbacks) {
-		if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, Quest)) // 0 is filter one, and we only use an argument so we don't need to check further filters
+	for (auto const& callback : thisEvent->event_callbacks) {
+		if (reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsBaseInFilter(0, Quest)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
 			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, thisEvent->num_max_args, Quest);
 		}
@@ -97,8 +97,8 @@ void __fastcall handleQuestStartStop(TESQuest* Quest, bool IsStarted) {
 }
 
 void __cdecl handleQuestComplete(TESQuest* Quest) {
-	for (auto const& callback : OnCompleteQuestHandler->EventCallbacks) {
-		if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, Quest)) // 0 is filter one, and we only use an argument so we don't need to check further filters
+	for (auto const& callback : OnCompleteQuestHandler->event_callbacks) {
+		if (reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsBaseInFilter(0, Quest)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
 			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnCompleteQuestHandler->num_max_args, Quest);
 		}
@@ -107,8 +107,8 @@ void __cdecl handleQuestComplete(TESQuest* Quest) {
 }
 
 void __cdecl handleQuestFail(TESQuest* Quest) {
-	for (auto const& callback : OnFailQuestHandler->EventCallbacks) {
-		if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, Quest)) // 0 is filter one, and we only use an argument so we don't need to check further filters
+	for (auto const& callback : OnFailQuestHandler->event_callbacks) {
+		if (reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsBaseInFilter(0, Quest)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
 			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnFailQuestHandler->num_max_args, Quest);
 		}
@@ -118,13 +118,13 @@ void __cdecl handleQuestFail(TESQuest* Quest) {
 
 void __cdecl handleSettingsUpdate() {
 	CdeclCall(0x7D6D70);
-	for (auto const& callback : OnSettingsUpdateHandler->EventCallbacks) {
+	for (auto const& callback : OnSettingsUpdateHandler->event_callbacks) {
 		FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnSettingsUpdateHandler->num_max_args);
 	}
 }
 ExtraDataList* __fastcall HandleSeenDataUpdateEvent(TESObjectCELL* cell) {
-	for (auto const& callback : OnSeenDataUpdateHandler->EventCallbacks) {
-		if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, cell)) // 0 is filter one, and we only use an argument so we don't need to check further filters
+	for (auto const& callback : OnSeenDataUpdateHandler->event_callbacks) {
+		if (reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsBaseInFilter(0, cell)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
 			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnSeenDataUpdateHandler->num_max_args, cell);
 		}
@@ -132,8 +132,8 @@ ExtraDataList* __fastcall HandleSeenDataUpdateEvent(TESObjectCELL* cell) {
 	return &cell->extraDataList;
 }
 UInt32 __fastcall HandleChallengeCompleteEvent(TESChallenge* challenge) {
-	for (auto const& callback : OnChallengeCompleteHandler->EventCallbacks) {
-		if (reinterpret_cast<JohnnyEventFiltersForm*>(callback.eventFilter)->IsBaseInFilter(0, challenge)) // 0 is filter one, and we only use an argument so we don't need to check further filters
+	for (auto const& callback : OnChallengeCompleteHandler->event_callbacks) {
+		if (reinterpret_cast<GenericEventFilters*>(callback.eventFilter)->IsBaseInFilter(0, challenge)) // 0 is filter one, and we only use an argument so we don't need to check further filters
 		{
 			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnChallengeCompleteHandler->num_max_args, challenge);
 		}
@@ -143,7 +143,7 @@ UInt32 __fastcall HandleChallengeCompleteEvent(TESChallenge* challenge) {
 
 
 UInt32 __fastcall handlerRenderGameEvent(void* ECX, void* edx, int arg1, int arg2, int arg3) {
-	for (auto const& callback : OnRenderGameModeUpdateHandler->EventCallbacks) {
+	for (auto const& callback : OnRenderGameModeUpdateHandler->event_callbacks) {
 
 			FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnRenderGameModeUpdateHandler->num_max_args);
 
@@ -152,7 +152,7 @@ UInt32 __fastcall handlerRenderGameEvent(void* ECX, void* edx, int arg1, int arg
 }
 
 UInt32 __fastcall handlerRenderMenuEvent(void* ECX, void* edx, int arg1, int arg2, int arg3) {
-	for (auto const& callback : OnRenderRenderedMenuUpdateHandler->EventCallbacks) {
+	for (auto const& callback : OnRenderRenderedMenuUpdateHandler->event_callbacks) {
 
 		FunctionCallScript(callback.ScriptForEvent, NULL, 0, &EventResultPtr, OnRenderRenderedMenuUpdateHandler->num_max_args);
 
@@ -206,17 +206,17 @@ __declspec (naked) void OnQuestStartStopEventAsm()
 bool Cmd_SetJohnnyOnLimbGoneEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
-	Script* script = NULL;
-	EventFilterStructOneFormOneInt filter = { NULL, -1 }; // you always need to make a array of pointers the size of the maximum arguments in the filter, it doesn't matter if most are empty. Framework caveat.
+	Script* script = nullptr;
+	EventFilter_OneForm_OneInt filter;
 	UInt32 flags = 0;
 	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter.form, &filter.intID) || NOT_TYPE(script, Script))) return true;
 	{
 		if (OnLimbGoneHandler)
 		{
+			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnLimbGoneHandler->RegisterEvent(script, (void**)&filter);
-			else OnLimbGoneHandler->RemoveEvent(script, (void**)&filter);
-
+				OnLimbGoneHandler->RegisterEvent(script, filterArr);
+			else OnLimbGoneHandler->RemoveEvent(script, filterArr);
 		}
 		return true;
 	}
@@ -224,16 +224,15 @@ bool Cmd_SetJohnnyOnLimbGoneEventHandler_Execute(COMMAND_ARGS)
 bool Cmd_SetJohnnyOnSettingsUpdateEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
-	Script* script = NULL;
+	Script* script = nullptr;
 	UInt32 flags = 0;
 	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags) || NOT_TYPE(script, Script))) return true;
 	{
 		if (OnSettingsUpdateHandler)
 		{
 			if (setOrRemove)
-				OnSettingsUpdateHandler->RegisterEvent(script, NULL);
-			else OnSettingsUpdateHandler->RemoveEvent(script, NULL);
-
+				OnSettingsUpdateHandler->RegisterEvent(script);
+			else OnSettingsUpdateHandler->RemoveEvent(script);
 		}
 		return true;
 	}
@@ -241,17 +240,17 @@ bool Cmd_SetJohnnyOnSettingsUpdateEventHandler_Execute(COMMAND_ARGS)
 bool Cmd_SetJohnnyOnCrosshairEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
-	Script* script = NULL;
-	EventFilterStructOneFormOneInt filter = { NULL, -1 };
+	Script* script = nullptr;
+	EventFilter_OneForm_OneInt filter;
 	UInt32 flags = 0;
 	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter.form, &filter.intID) || NOT_TYPE(script, Script))) return true;
 	{
 		if (OnCrosshairHandler)
 		{
+			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnCrosshairHandler->RegisterEvent(script, (void**)&filter);
-			else OnCrosshairHandler->RemoveEvent(script, (void**)&filter);
-
+				OnCrosshairHandler->RegisterEvent(script, filterArr);
+			else OnCrosshairHandler->RemoveEvent(script, filterArr);
 		}
 		return true;
 	}
@@ -260,16 +259,16 @@ bool Cmd_SetJohnnyOnRemovePerkEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
 	Script* script = NULL;
-	TESForm* filter[1] = { NULL };
+	EventFilter_OneForm filter;
 	UInt32 flags = 0;
-	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter[0]) || NOT_TYPE(script, Script))) return true;
+	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter.form) || NOT_TYPE(script, Script))) return true;
 	{
 		if (OnRemovePerkHandler)
 		{
+			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnRemovePerkHandler->RegisterEvent(script, (void**)filter);
-			else OnRemovePerkHandler->RemoveEvent(script, (void**)filter);
-
+				OnRemovePerkHandler->RegisterEvent(script, filterArr);
+			else OnRemovePerkHandler->RemoveEvent(script, filterArr);
 		}
 		return true;
 	}
@@ -278,16 +277,16 @@ bool Cmd_SetJohnnyOnAddPerkEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
 	Script* script = NULL;
-	TESForm* filter[1] = { NULL };
+	EventFilter_OneForm filter;
 	UInt32 flags = 0;
-	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter[0]) || NOT_TYPE(script, Script))) return true;
+	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter) || NOT_TYPE(script, Script))) return true;
 	{
 		if (OnAddPerkHandler)
 		{
+			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnAddPerkHandler->RegisterEvent(script, (void**)filter);
-			else OnAddPerkHandler->RemoveEvent(script, (void**)filter);
-
+				OnAddPerkHandler->RegisterEvent(script, filterArr);
+			else OnAddPerkHandler->RemoveEvent(script, filterArr);
 		}
 		return true;
 	}
@@ -296,16 +295,16 @@ bool Cmd_SetJohnnyOnChallengeCompleteEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
 	Script* script = NULL;
-	TESForm* filter[1] = { NULL };
+	EventFilter_OneForm filter;
 	UInt32 flags = 0;
-	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter[0]) || NOT_TYPE(script, Script))) return true;
+	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter.form) || NOT_TYPE(script, Script))) return true;
 	{
 		if (OnChallengeCompleteHandler)
 		{
+			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnChallengeCompleteHandler->RegisterEvent(script, (void**)filter);
-			else OnChallengeCompleteHandler->RemoveEvent(script, (void**)filter);
-
+				OnChallengeCompleteHandler->RegisterEvent(script, filterArr);
+			else OnChallengeCompleteHandler->RemoveEvent(script, filterArr);
 		}
 		return true;
 	}
@@ -314,16 +313,16 @@ bool Cmd_SetJohnnySeenDataEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
 	Script* script = NULL;
-	TESForm* filter[1] = { NULL }; // you always need to make a array of pointers the size of the maximum arguments in the filter, it doesn't matter if most are empty. Framework caveat.
+	EventFilter_OneForm filter;
 	UInt32 flags = 0;
-	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter[0]) || NOT_TYPE(script, Script))) return true;
+	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter.form) || NOT_TYPE(script, Script))) return true;
 	{
 		if (OnSeenDataUpdateHandler)
 		{
+			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnSeenDataUpdateHandler->RegisterEvent(script, (void**)filter);
-			else OnSeenDataUpdateHandler->RemoveEvent(script, (void**)filter);
-
+				OnSeenDataUpdateHandler->RegisterEvent(script, filterArr);
+			else OnSeenDataUpdateHandler->RemoveEvent(script, filterArr);
 		}
 		return true;
 	}
@@ -332,16 +331,16 @@ bool Cmd_SetJohnnyOnDyingEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
 	Script* script = NULL;
-	TESForm* filter[1] = { NULL }; // you always need to make a array of pointers the size of the maximum arguments in the filter, it doesn't matter if most are empty. Framework caveat.
+	EventFilter_OneForm filter;
 	UInt32 flags = 0;
-	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter[0]) || NOT_TYPE(script, Script))) return true;
+	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter.form) || NOT_TYPE(script, Script))) return true;
 	{
 		if (OnDyingHandler)
 		{
+			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnDyingHandler->RegisterEvent(script, (void**)filter);
-			else OnDyingHandler->RemoveEvent(script, (void**)filter);
-
+				OnDyingHandler->RegisterEvent(script, filterArr);
+			else OnDyingHandler->RemoveEvent(script, filterArr);
 		}
 		return true;
 	}
@@ -351,16 +350,16 @@ bool Cmd_SetJohnnyOnStartQuestEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
 	Script* script = NULL;
-	TESForm* filter[1] = { NULL }; // you always need to make a array of pointers the size of the maximum arguments in the filter, it doesn't matter if most are empty. Framework caveat.
+	EventFilter_OneForm filter;
 	UInt32 flags = 0;
-	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter[0]) || NOT_TYPE(script, Script))) return true;
+	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter.form) || NOT_TYPE(script, Script))) return true;
 	{
 		if (OnStartQuestHandler)
 		{
+			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnStartQuestHandler->RegisterEvent(script, (void**)filter);
-			else OnStartQuestHandler->RemoveEvent(script, (void**)filter);
-
+				OnStartQuestHandler->RegisterEvent(script, filterArr);
+			else OnStartQuestHandler->RemoveEvent(script, filterArr);
 		}
 		return true;
 	}
@@ -371,16 +370,16 @@ bool Cmd_SetJohnnyOnStopQuestEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
 	Script* script = NULL;
-	TESForm* filter[1] = { NULL }; // you always need to make a array of pointers the size of the maximum arguments in the filter, it doesn't matter if most are empty. Framework caveat.
+	EventFilter_OneForm filter;
 	UInt32 flags = 0;
-	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter[0]) || NOT_TYPE(script, Script))) return true;
+	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter.form) || NOT_TYPE(script, Script))) return true;
 	{
 		if (OnStopQuestHandler)
 		{
+			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnStopQuestHandler->RegisterEvent(script, (void**)filter);
-			else OnStopQuestHandler->RemoveEvent(script, (void**)filter);
-
+				OnStopQuestHandler->RegisterEvent(script, filterArr);
+			else OnStopQuestHandler->RemoveEvent(script, filterArr);
 		}
 		return true;
 	}
@@ -390,16 +389,16 @@ bool Cmd_SetJohnnyOnCompleteQuestEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
 	Script* script = NULL;
-	TESForm* filter[1] = { NULL };
+	EventFilter_OneForm filter;
 	UInt32 flags = 0;
-	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter[0]) || NOT_TYPE(script, Script))) return true;
+	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter.form) || NOT_TYPE(script, Script))) return true;
 	{
 		if (OnCompleteQuestHandler)
 		{
+			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnCompleteQuestHandler->RegisterEvent(script, (void**)filter);
-			else OnCompleteQuestHandler->RemoveEvent(script, (void**)filter);
-
+				OnCompleteQuestHandler->RegisterEvent(script, filterArr);
+			else OnCompleteQuestHandler->RemoveEvent(script, filterArr);
 		}
 		return true;
 	}
@@ -409,18 +408,16 @@ bool Cmd_SetJohnnyOnFailQuestEventHandler_Execute(COMMAND_ARGS)
 {
 	UInt32 setOrRemove = 0;
 	Script* script = NULL;
-	TESForm* filter;
+	EventFilter_OneForm filter;
 	UInt32 flags = 0;
-	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter) || NOT_TYPE(script, Script))) return true;
+	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags, &filter.form) || NOT_TYPE(script, Script))) return true;
 	{
-		FormSet formSet { filter };
-		FilterTypeSets genericSet = formSet;
 		if (OnFailQuestHandler)
 		{
+			auto filterArr = filter.ToFilter();
 			if (setOrRemove)
-				OnFailQuestHandler->RegisterEvent(script, genericSet);
-			else OnFailQuestHandler->RemoveEvent(script, genericSet);
-
+				OnFailQuestHandler->RegisterEvent(script, filterArr);
+			else OnFailQuestHandler->RemoveEvent(script, filterArr);
 		}
 		return true;
 	}
@@ -437,21 +434,18 @@ bool Cmd_SetJohnnyOnRenderUpdateEventHandler_Execute(COMMAND_ARGS)
 	};
 	if (!(ExtractArgsEx(EXTRACT_ARGS_EX, &setOrRemove, &script, &flags) || NOT_TYPE(script, Script))) return true;
 	{
-		FilterTypeSetArray nullArr;
 		if (!(flags & kDoNotFireInGameMode) && OnRenderGameModeUpdateHandler)
 		{
 			if (setOrRemove)
-				OnRenderGameModeUpdateHandler->RegisterEvent(script, nullArr);
-			else OnRenderGameModeUpdateHandler->RemoveEvent(script, nullArr);
-
+				OnRenderGameModeUpdateHandler->RegisterEvent(script);
+			else OnRenderGameModeUpdateHandler->RemoveEvent(script);
 		}
 
 		if (!(flags & kDoNotFireInRenderMenu) && OnRenderRenderedMenuUpdateHandler)
 		{
 			if (setOrRemove)
-				OnRenderRenderedMenuUpdateHandler->RegisterEvent(script, nullArr);
-			else OnRenderRenderedMenuUpdateHandler->RemoveEvent(script, nullArr);
-
+				OnRenderRenderedMenuUpdateHandler->RegisterEvent(script);
+			else OnRenderRenderedMenuUpdateHandler->RemoveEvent(script);
 		}
 		return true;
 	}
@@ -492,9 +486,9 @@ void HandleEventHooks()
 
 
 	//testing
-	OnRenderGameModeUpdateHandler = JGCreateEvent("OnRenderGameModeUpdateHandler", 0, 0, NULL);
+	OnRenderGameModeUpdateHandler = JGCreateEvent("OnRenderGameModeUpdateHandler", 0, 0);
 	WriteRelCall(0x870244, (uintptr_t)handlerRenderGameEvent);
-	OnRenderRenderedMenuUpdateHandler = JGCreateEvent("OnRenderRenderedMenuUpdateHandler", 0, 0, NULL);
+	OnRenderRenderedMenuUpdateHandler = JGCreateEvent("OnRenderRenderedMenuUpdateHandler", 0, 0);
 	WriteRelCall(0x8702A9, (uintptr_t)handlerRenderMenuEvent);
 
 }

--- a/JG/exports.def
+++ b/JG/exports.def
@@ -3,6 +3,4 @@ EXPORTS
 NVSEPlugin_Query
 NVSEPlugin_Load
 JGNVSE_GetFormIDFromEDID
-JGCreateEvent
-JGFreeEvent
 JG_WorldToScreen

--- a/JG/nvse_plugin_example.vcxproj
+++ b/JG/nvse_plugin_example.vcxproj
@@ -237,6 +237,7 @@
     <ClInclude Include="..\nvse\nvse\Utilities.h" />
     <ClInclude Include="events\CustomEventFilters.h" />
     <ClInclude Include="events\EventFilteringInterface.h" />
+    <ClInclude Include="events\EventFilterStructs.h" />
     <ClInclude Include="events\JohnnyEventPredefinitions.h" />
     <ClInclude Include="events\JohnnyEvents.h" />
     <ClInclude Include="events\LambdaVariableContext.h" />

--- a/JG/nvse_plugin_example.vcxproj.filters
+++ b/JG/nvse_plugin_example.vcxproj.filters
@@ -218,6 +218,9 @@
     <ClInclude Include="events\LambdaVariableContext.h">
       <Filter>events</Filter>
     </ClInclude>
+    <ClInclude Include="events\EventFilterStructs.h">
+      <Filter>events</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="exports.def" />


### PR DESCRIPTION
New filters should be easier to make now, thanks to an abuse of `std::variant` and `std::visit` in order to support multiple variable types. See `CustomEventFilters.h` for what making a new filter looks like.

While RefIDs are currently the only elements that fully utilize the `RefIDSet` type by having more than 1 elem if a formlist is passed (elements from that get dumped into the set), the other typed sets could easily find use if arrays were to be passed as filters.
For example, an array of `formType` int codes could be used to declare that the event should only run for X, Y and Z formTypes.

Every event is now templated with the filter they'll be using, in order to enforce passing the right amount and type of arguments. This also let me remove the `numMaxFilters` field from the `EventInformation` class.
I have refactored every JG event to use this system.
A downside to this is that more code will have to be generated upon compilation, increasing the DLL size. I have no idea how much of an issue this'll be, but by comparing the nexus JG .dll to the .dll I have, it has increased by ~20kb.

I've also fixed `EventInformation::RemoveEvent` not mass-unregistering UDFs when called with default values, See examples [on Discord](https://discord.com/channels/481649736634466305/486983321264586752/886933449410244618).
I did this by calling an alternative filter comparison function that skips checking for equality for default-value filters.

I've added the `eFlag_FlushOnLoad` flag, in order to make flush-on-load events easier to maintain (don't have to go look elsewhere to see if the event is being flushed, just check the declaration). 
A drawback is that every event will need to be looped over on load, but it's already being looped over every frame in `kMessage_MainGameLoop` so it shouldn't matter much.

I have also made `RegisterEvent` return a bool, though that's unused for now. Perhaps in the future, `RemoveEvent` could return how many UDFs were cleared. I think that would be handy info for the JG event functions to return.

In order to do these changes, I also got rid of the `JGCreate/RemoveEvent` export. Not sure if it could be added back later. 
But if it really requires working with raw data pointers, I'd rather just port this whole code entirely rather than use the exports so I can get some type safety and convenience.