### PR TITLE
IsCellExpired - add ResetInteriorAlt compatibility (for ShowOff)

### DIFF
--- a/JG/functions/fn_form.h
+++ b/JG/functions/fn_form.h
@@ -1371,7 +1371,7 @@ bool Cmd_IsCellExpired_Execute(COMMAND_ARGS) {
 		if (detachTime == 0) {
 			*result = -1;
 		}
-		else if (detachTime == -1) {
+		else if (detachTime == -1 || detachTime == -2) {	//-1 is used by ResetInterior, -2 by ShowOff's ResetInteriorAlt.
 			*result = 1;
 		}
 		else {


### PR DESCRIPTION
I'm using -2 as a way to differentiate if the regular or alt ResetInterior was called.
(The Alt version revives dead actors thanks to hooks, which either doesn't happen or is inconsistent for the regular version).