### PR TITLE
Fix GetAmmoInInventory returning non-ammo forms

### DIFF
--- a/JG/JohnnyGuitarNVSE.h
+++ b/JG/JohnnyGuitarNVSE.h
@@ -276,8 +276,10 @@ TESForm* __fastcall GetAmmoInInventory(TESObjectWEAP* weap) {
 			if (ammoList && xChanges && xChanges->data) {
 				for (int i = 0; i < ammoList->Count(); i++) {
 					ammo = ammoList->GetNthForm(i);
-					UInt32 count = ThisStdCall<UInt32>(0x4C8F30, xChanges->data, ammo);
-					if (count > 0) return ammo;
+					if (IS_TYPE(ammo, TESAmmo)) {
+						UInt32 count = ThisStdCall<UInt32>(0x4C8F30, xChanges->data, ammo);
+						if (count > 0) return ammo;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
GetAmmoInInventory was returning TESObjectMISC items when hovering over the rock-it-launcher, which caused a crash when evaluating the ammo effects - it should return null in this case.