### PR TITLE
more casino functions - Get/SetCasinoDeckTexture, Get/SetCasinoChip

### DIFF
--- a/JG/JohnnyGuitarNVSE.cpp
+++ b/JG/JohnnyGuitarNVSE.cpp
@@ -510,8 +510,8 @@ extern "C" {
 		REG_CMD(SetCasinoWinnings);
 		REG_TYPED_CMD(GetCasinoDeckTexture, String);
 		REG_CMD(SetCasinoDeckTexture);
-		REG_TYPED_CMD(GetCasinoCurrency, Form);
-		REG_CMD(SetCasinoCurrency);
+		REG_TYPED_CMD(GetCasinoChip, Form);
+		REG_CMD(SetCasinoChip);
 		REG_CMD(GetAcousticSpace);
 		REG_CMD(SetAcousticSpace);
 		REG_CMD(SetCameraTranslate);

--- a/JG/JohnnyGuitarNVSE.cpp
+++ b/JG/JohnnyGuitarNVSE.cpp
@@ -508,6 +508,10 @@ extern "C" {
 		REG_CMD(ClearMediaLocationControllerOverride); // do not document
 		REG_CMD(GetCasinoWinnings);
 		REG_CMD(SetCasinoWinnings);
+		REG_TYPED_CMD(GetCasinoDeckTexture, String);
+		REG_CMD(SetCasinoDeckTexture);
+		REG_TYPED_CMD(GetCasinoCurrency, Form);
+		REG_CMD(SetCasinoCurrency);
 		REG_CMD(GetAcousticSpace);
 		REG_CMD(SetAcousticSpace);
 		REG_CMD(SetCameraTranslate);

--- a/JG/JohnnyGuitarNVSE.cpp
+++ b/JG/JohnnyGuitarNVSE.cpp
@@ -508,10 +508,6 @@ extern "C" {
 		REG_CMD(ClearMediaLocationControllerOverride); // do not document
 		REG_CMD(GetCasinoWinnings);
 		REG_CMD(SetCasinoWinnings);
-		REG_TYPED_CMD(GetCasinoDeckTexture, String);
-		REG_CMD(SetCasinoDeckTexture);
-		REG_TYPED_CMD(GetCasinoChip, Form);
-		REG_CMD(SetCasinoChip);
 		REG_CMD(GetAcousticSpace);
 		REG_CMD(SetAcousticSpace);
 		REG_CMD(SetCameraTranslate);
@@ -519,6 +515,10 @@ extern "C" {
 		REG_CMD(PlayHolotape);
 		REG_CMD(StopHolotape);
 		REG_CMD(SetOnTakeBackItemEventHandler);
+		REG_TYPED_CMD(GetCasinoDeckTexture, String);
+		REG_CMD(SetCasinoDeckTexture);
+		REG_TYPED_CMD(GetCasinoChip, Form);
+		REG_CMD(SetCasinoChip);
 
 		g_scriptInterface = (NVSEScriptInterface*)nvse->QueryInterface(kInterface_Script);
 		g_cmdTableInterface = (NVSECommandTableInterface*)nvse->QueryInterface(kInterface_CommandTable);

--- a/JG/functions/fn_gameplay.h
+++ b/JG/functions/fn_gameplay.h
@@ -64,6 +64,10 @@ DEFINE_COMMAND_ALT_PLUGIN(SetMediaLocationControllerOverride, SetMLCOverride, , 
 DEFINE_COMMAND_ALT_PLUGIN(ClearMediaLocationControllerOverride, ClearMLCOverride, , 0, 0, NULL);
 DEFINE_COMMAND_ALT_PLUGIN(GetCasinoWinnings, , , 0, 1, kParams_OneCasino);
 DEFINE_COMMAND_ALT_PLUGIN(SetCasinoWinnings, , , 0, 2, kParams_OneCasinoOneInt);
+DEFINE_COMMAND_PLUGIN(GetCasinoDeckTexture, , 0, 2, kParams_OneCasinoOneInt);
+DEFINE_COMMAND_PLUGIN(SetCasinoDeckTexture, , 0, 3, kParams_OneCasinoOneIntOneString);
+DEFINE_COMMAND_PLUGIN(GetCasinoCurrency, , 0, 1, kParams_OneCasino);
+DEFINE_COMMAND_PLUGIN(SetCasinoCurrency, , 0, 2, kParams_OneCasinoOneForm);
 DEFINE_COMMAND_PLUGIN(PlayHolotape, , 0, 2, kParams_OneForm_OneOptionalInt);
 DEFINE_COMMAND_PLUGIN(StopHolotape, , 0, 1, kParams_OneOptionalInt);
 void(__cdecl* HandleActorValueChange)(ActorValueOwner* avOwner, int avCode, float oldVal, float newVal, ActorValueOwner* avOwner2) =
@@ -157,6 +161,62 @@ bool __cdecl Cmd_GetCasinoWinnings_Execute(COMMAND_ARGS)
 		} while (iter = iter->next);
 	}
 
+	return true;
+}
+
+bool Cmd_GetCasinoDeckTexture_Execute(COMMAND_ARGS)
+{
+	*result = 0;
+	TESCasino* casino = nullptr;
+	SInt32 deckIndex;
+	const char* resStr = NULL;
+	if (ExtractArgsEx(EXTRACT_ARGS_EX, &casino, &deckIndex) && casino && deckIndex >= 0 && deckIndex <= 3)
+	{
+		resStr = casino->blackjackDeck[deckIndex].ddsPath.m_data;
+		if (IsConsoleMode())
+			Console_Print("GetCasinoDeckTexture >> %s", resStr);
+		g_strInterface->Assign(PASS_COMMAND_ARGS, resStr);
+	}
+	return true;
+}
+
+bool Cmd_SetCasinoDeckTexture_Execute(COMMAND_ARGS)
+{
+	*result = 0;
+	TESCasino* casino = nullptr;
+	SInt32 deckIndex;
+	char newPath[MAX_PATH];
+	if (ExtractArgsEx(EXTRACT_ARGS_EX, &casino, &deckIndex, &newPath) && casino && newPath && deckIndex >= 0 && deckIndex <= 3)
+	{
+		casino->blackjackDeck[deckIndex].ddsPath.Set(newPath);
+		*result = 1;
+	}
+	return true;
+}
+
+bool Cmd_GetCasinoCurrency_Execute(COMMAND_ARGS)
+{
+	*result = 0;
+	TESCasino* casino = nullptr;
+	TESForm* chipForm = nullptr;
+	if (ExtractArgsEx(EXTRACT_ARGS_EX, &casino) && casino)
+	{
+		chipForm = TESForm::GetFormByNumericID(casino->currencyRefID);
+		*(UInt32*)result = chipForm->refID;
+	}
+	return true;
+}
+
+bool Cmd_SetCasinoCurrency_Execute(COMMAND_ARGS)
+{
+	*result = 0;
+	TESCasino* casino = nullptr;
+	TESForm* chip = nullptr;
+	if (ExtractArgsEx(EXTRACT_ARGS_EX, &casino, &chip) && casino && chip && IS_TYPE(chip, TESCasinoChips))
+	{
+		casino->currencyRefID = chip->refID;
+		*result = 1;
+	}
 	return true;
 }
 

--- a/JG/functions/fn_gameplay.h
+++ b/JG/functions/fn_gameplay.h
@@ -66,8 +66,8 @@ DEFINE_COMMAND_ALT_PLUGIN(GetCasinoWinnings, , , 0, 1, kParams_OneCasino);
 DEFINE_COMMAND_ALT_PLUGIN(SetCasinoWinnings, , , 0, 2, kParams_OneCasinoOneInt);
 DEFINE_COMMAND_PLUGIN(GetCasinoDeckTexture, , 0, 2, kParams_OneCasinoOneInt);
 DEFINE_COMMAND_PLUGIN(SetCasinoDeckTexture, , 0, 3, kParams_OneCasinoOneIntOneString);
-DEFINE_COMMAND_PLUGIN(GetCasinoCurrency, , 0, 1, kParams_OneCasino);
-DEFINE_COMMAND_PLUGIN(SetCasinoCurrency, , 0, 2, kParams_OneCasinoOneForm);
+DEFINE_COMMAND_PLUGIN(GetCasinoChip, , 0, 1, kParams_OneCasino);
+DEFINE_COMMAND_PLUGIN(SetCasinoChip, , 0, 2, kParams_OneCasinoOneForm);
 DEFINE_COMMAND_PLUGIN(PlayHolotape, , 0, 2, kParams_OneForm_OneOptionalInt);
 DEFINE_COMMAND_PLUGIN(StopHolotape, , 0, 1, kParams_OneOptionalInt);
 void(__cdecl* HandleActorValueChange)(ActorValueOwner* avOwner, int avCode, float oldVal, float newVal, ActorValueOwner* avOwner2) =
@@ -194,7 +194,7 @@ bool Cmd_SetCasinoDeckTexture_Execute(COMMAND_ARGS)
 	return true;
 }
 
-bool Cmd_GetCasinoCurrency_Execute(COMMAND_ARGS)
+bool Cmd_GetCasinoChip_Execute(COMMAND_ARGS)
 {
 	*result = 0;
 	TESCasino* casino = nullptr;
@@ -207,7 +207,7 @@ bool Cmd_GetCasinoCurrency_Execute(COMMAND_ARGS)
 	return true;
 }
 
-bool Cmd_SetCasinoCurrency_Execute(COMMAND_ARGS)
+bool Cmd_SetCasinoChip_Execute(COMMAND_ARGS)
 {
 	*result = 0;
 	TESCasino* casino = nullptr;

--- a/nvse/nvse/ParamInfos.h
+++ b/nvse/nvse/ParamInfos.h
@@ -870,7 +870,7 @@ static ParamInfo kParams_OneCasinoOneIntOneString[3] =
 static ParamInfo kParams_OneCasinoOneForm[2] =
 {
 	{	"Casino",	kParamType_Casino,	1	},
-	{	"Chip",		kParamType_AnyForm,	1	},
+	{	"form",		kParamType_AnyForm,	1	},
 };
 
 

--- a/nvse/nvse/ParamInfos.h
+++ b/nvse/nvse/ParamInfos.h
@@ -851,13 +851,26 @@ static ParamInfo kParams_EjectCasing[2] =
 
 static ParamInfo kParams_OneCasino[1] =
 {
-	{    "Casino",    kParamType_Casino,    1    },
+	{	"Casino",	kParamType_Casino,	1	},
 };
 
 static ParamInfo kParams_OneCasinoOneInt[2] =
 {
-	{    "Casino",    kParamType_Casino,    1    },
-	{    "Earnings",    kParamType_Integer,    1    },
+	{	"Casino",	kParamType_Casino,	1	},
+	{	"int",		kParamType_Integer,	1	},
+};
+
+static ParamInfo kParams_OneCasinoOneIntOneString[3] =
+{
+	{	"Casino",	kParamType_Casino,	1	},
+	{	"int",		kParamType_Integer,	1	},
+	{	"string",	kParamType_String,	1	},
+};
+
+static ParamInfo kParams_OneCasinoOneForm[2] =
+{
+	{	"Casino",	kParamType_Casino,	1	},
+	{	"Chip",		kParamType_AnyForm,	1	},
 };
 
 


### PR DESCRIPTION
- 4 new casino functions:
  - GetCasinoDeckTexture(casino, deckIndex) - returns the texture path for the back of the specified deck (index 0–3) used by the casino
  - SetCasinoDeckTexture(casino, deckIndex, texturePath) - sets the back texture of the specified deck (index 0–3) for the given casino, in effect setting textures for the whole deck (for current session, not savebaked)
  - GetCasinoChip(casino) - returns that casino's currency (chip)
  - SetCasinoChip(casino, ref) - sets the ref as that casino's currency (if it is a chip) (for current session, not savebaked)
- added the required parameters - kParams_OneCasinoOneIntOneString, kParams_OneCasinoOneForm
- code style - replaced some spaces with tabs in ParamInfos.h
- clarity - renamed "Earnings" in kParams_OneCasinoOneInt to "int" because it now serves as both earnings and deck index