### PR TITLE
add SetCellImageSpace fix

### DIFF
--- a/JG/JohnnyGuitarNVSE.h
+++ b/JG/JohnnyGuitarNVSE.h
@@ -1763,7 +1763,15 @@ bool __cdecl IsCurrentFurnitureRefHook(TESObjectREFR* apRef, void* apComparedRef
 	return true;
 }
 
+void __fastcall SetCellImageSpaceHook(TESObjectCELL* cell, void* edx, TESImageSpace* imageSpace) {
 
+
+	ThisCall<void>(0x547750, cell, imageSpace);
+	PlayerCharacter* player = PlayerCharacter::GetSingleton();
+	if (player->parentCell != nullptr && player->parentCell == cell) {
+		CdeclCall<void>(0xB4F430, imageSpace->traitValues);
+	}
+}
 
 
 
@@ -1852,6 +1860,8 @@ void HandleFixes() {
 	hk_DialogueTopicResponseManageHook::InitHooks();
 	hk_EmotionOverrideUndo< 0x0617D59>();
 	hk_QuestObjectiveIsDisplayedCall<0x05A5E70>();
+
+	WriteRelCall(0x5B7812, (UInt32)SetCellImageSpaceHook);
 }
 
 void HandleIniOptions() {
@@ -2030,9 +2040,4 @@ void HandleGameHooks() {
 	HandleIniOptions();
 	HandleFunctionPatches();
 	HandleGameSettingsJG();
-	//  wip shit for void
-	//	WriteRelCall(0x97E745, (UInt32)WantsToFleeHook);
-	//	WriteRelCall(0x999082, (UInt32)WantsToFleeHook);
-	//	WriteRelCall(0x9AAC17, (UInt32)WantsToFleeHook);
-	//  SafeWrite32(0x8868CF, (UInt32)&timer22);
 }


### PR DESCRIPTION
After calling SetCellImageSpace on a cell that is currently loaded, the ImageSpace will not be refreshed until the cell is reloaded. This will happen if the player moves away from the cell then back to the cell, or if a save made in the cell (with the new ImageSpace) is loaded from the menu. 