### PR TITLE
Patch OGG/WAV Radio playback

### DIFF
--- a/JG/internal/JG/JohnnyPatches.cpp
+++ b/JG/internal/JG/JohnnyPatches.cpp
@@ -19,6 +19,7 @@
 #include "DisabledArrowKeys.hpp"
 #include "AddItemMessages.hpp"
 #include "ExtraMarkerIcons.hpp"
+#include "RadioSkipOGGWAVPatch.hpp"
 
 namespace JohnnyPatches {
 	bool fixFleeing = false;
@@ -35,6 +36,7 @@ namespace JohnnyPatches {
 	bool bDisableDLLCompatibilityRoutines = false;
 	bool bCombatMusicDisabled = false;
 	bool bMultipleAddItemMessages = false;
+	bool bFixOggWavRadioPlayback = false;
 
 	unsigned int iFPSCapLoadScreen = 0;
 	float iDeathSoundMAXTimer = 10;
@@ -231,12 +233,16 @@ namespace JohnnyPatches {
 		patchPainedPlayer = GetPrivateProfileInt("MAIN", "bRemovePlayerPainExpression", 0, filename);
 		bMultipleAddItemMessages = GetPrivateProfileInt("MAIN", "bMultipleAddItemMessages", 0, filename);
 		bFixJIP = GetPrivateProfileInt("MAIN", "bJIPFixes", 1, filename);
+		bFixOggWavRadioPlayback = GetPrivateProfileInt("MAIN", "bFixOggWavRadioPlayback", 1, filename);
 		iDeathSoundMAXTimer = GetPrivateProfileInt("DeathResponses", "iDeathSoundMAXTimer", 10, filename); //Hidden, don't actually expose it in the INI
 		bDisableDLLCompatibilityRoutines = GetPrivateProfileInt("Misc", "bDisableDLLCompatibilityRoutines", 0, filename); //Hidden
 	}
 
 	void Install() {
 
+		if (bFixOggWavRadioPlayback) {
+			RadioSkipOGGWAVPatch::Install();
+		}
 		// for bFixFleeing
 		if (fixFleeing) WriteRelCall(0x8F5FE2, (uint32_t)FleeFixHook);
 
@@ -321,6 +327,9 @@ namespace JohnnyPatches {
 		CameraOverride::Install();
 
 		WriteRelCall(0x798BB1, (uint32_t)StopHolotapeSoundHook);
+
+
+
 	}
 
 }

--- a/JG/internal/JG/RadioSkipOGGWAVPatch.cpp
+++ b/JG/internal/JG/RadioSkipOGGWAVPatch.cpp
@@ -1,0 +1,40 @@
+#include "RadioSkipOGGWAVPatch.hpp"
+#include "GameForms.h"
+#include <GameObjects.h>
+#include <decoding.h>
+
+
+namespace RadioSkipOGGWAVPatch {
+	ULONGLONG uiLastPipRadioUpdate;
+	void* hk_QueueRadioSkipUpdate()
+	{
+		auto* pEbp = GetParentBasePtr(_AddressOfReturnAddress(), false);
+		RadioEntry* pRadio = *((decltype(&pRadio))(pEbp + 0x8));
+		RadioEntry* pGlobalRadio = *((decltype(&pGlobalRadio))(0x11DD42C));
+		if (pRadio == pGlobalRadio)
+		{
+			uiLastPipRadioUpdate = GetTickCount64() + 200; //you'd have to be running at 5 fps for this to be an issue
+		}
+		return CdeclCall<void*>(0x453A70);
+
+	}
+
+	void* __fastcall hk_QueryRadioSkipUpdatePipboy(void* sound, void* edx, int offset)
+	{
+		if (uiLastPipRadioUpdate > GetTickCount64())
+		{
+			return NULL;
+		}
+		return  ThisCall<void*>(0xAD8FD0, sound, offset);
+	}
+
+
+
+	void Install() {
+
+		WriteRelCall(0x834749, (uint32_t)hk_QueueRadioSkipUpdate);
+		WriteRelCall(0x8337F7, (uint32_t)hk_QueryRadioSkipUpdatePipboy);
+
+	}
+
+}

--- a/JG/internal/JG/RadioSkipOGGWAVPatch.hpp
+++ b/JG/internal/JG/RadioSkipOGGWAVPatch.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include "JG\JGSetList.hpp"
+#include "GameForms.h"
+
+namespace RadioSkipOGGWAVPatch {
+	void Install();
+};

--- a/JG/nvse_plugin_example.vcxproj
+++ b/JG/nvse_plugin_example.vcxproj
@@ -219,6 +219,7 @@ copy "$(TargetDir)$(TargetName).pdb" "C:\Symbols\$(TargetName).pdb"
     <ClCompile Include="internal\JG\MediaLocationControllerOverride.cpp" />
     <ClCompile Include="internal\JG\NPCAccuracy.cpp" />
     <ClCompile Include="internal\JG\QuestObjectiveDisplayFix.cpp" />
+    <ClCompile Include="internal\JG\RadioSkipOGGWAVPatch.cpp" />
     <ClCompile Include="internal\JG\RSMBarberHook.cpp" />
     <ClCompile Include="internal\JG\TaskQueue.cpp" />
     <ClCompile Include="internal\JIP\JIPFixes.cpp" />
@@ -430,6 +431,7 @@ copy "$(TargetDir)$(TargetName).pdb" "C:\Symbols\$(TargetName).pdb"
     <ClInclude Include="internal\JG\MediaLocationControllerOverride.hpp" />
     <ClInclude Include="internal\JG\NPCAccuracy.hpp" />
     <ClInclude Include="internal\JG\QuestObjectiveDisplayFix.hpp" />
+    <ClInclude Include="internal\JG\RadioSkipOGGWAVPatch.hpp" />
     <ClInclude Include="internal\JG\RSMBarberHook.hpp" />
     <ClInclude Include="internal\JG\TaskQueue.hpp" />
     <ClInclude Include="internal\JIP\JIPFixes.hpp" />

--- a/JG/nvse_plugin_example.vcxproj.filters
+++ b/JG/nvse_plugin_example.vcxproj.filters
@@ -370,6 +370,9 @@
     <ClCompile Include="internal\Game\Bethesda\TESLeveledList.cpp">
       <Filter>internal\Game\Bethesda</Filter>
     </ClCompile>
+    <ClCompile Include="internal\JG\RadioSkipOGGWAVPatch.cpp">
+      <Filter>internal\JG</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\nvse\nvse\GameAPI.h">
@@ -999,6 +1002,9 @@
     </ClInclude>
     <ClInclude Include="internal\CommandOpcodes.h">
       <Filter>internal</Filter>
+    </ClInclude>
+    <ClInclude Include="internal\JG\RadioSkipOGGWAVPatch.hpp">
+      <Filter>internal\JG</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The game's radio is slightly bugged, if OGG or WAV plays, it tends to skip around 500 ms of playback.
This patch, while not a true fix, solves the issue.
Set as optional due to not being a "true" fix.