### PR TITLE
Patch known OGG/WAV playback issues

### DIFF
--- a/JG/internal/JG/RadioSkipOGGWAVPatch.cpp
+++ b/JG/internal/JG/RadioSkipOGGWAVPatch.cpp
@@ -1,39 +1,54 @@
 #include "RadioSkipOGGWAVPatch.hpp"
 #include "GameForms.h"
-#include <GameObjects.h>
-#include <decoding.h>
-
+#include "GameSound.h"
 
 namespace RadioSkipOGGWAVPatch {
-	ULONGLONG uiLastPipRadioUpdate;
-	void* hk_QueueRadioSkipUpdate()
+	//Fix playback
+	unsigned int BSWin32Audio_GetTimePassed()
 	{
-		auto* pEbp = GetParentBasePtr(_AddressOfReturnAddress(), false);
-		RadioEntry* pRadio = *((decltype(&pRadio))(pEbp + 0x8));
-		RadioEntry* pGlobalRadio = *((decltype(&pGlobalRadio))(0x11DD42C));
-		if (pRadio == pGlobalRadio)
-		{
-			uiLastPipRadioUpdate = GetTickCount64() + 200; //you'd have to be running at 5 fps for this to be an issue
-		}
-		return CdeclCall<void*>(0x453A70);
+		auto pBSWin32Audio = BSWin32Audio::GetSingleton();
+		return ThisCall<unsigned int>(0x63D040, pBSWin32Audio);
 
 	}
-
-	void* __fastcall hk_QueryRadioSkipUpdatePipboy(void* sound, void* edx, int offset)
+	void* hk_QueryRadioSkipUpdate(BSSoundHandle* pSound, unsigned int offset, bool bDoRewind)
 	{
-		if (uiLastPipRadioUpdate > GetTickCount64())
+		unsigned int msToRewind = 50; //the default value added by the game to skip
+		unsigned int setOffset = offset - msToRewind;
+		if (bDoRewind && ((BSWin32Audio_GetTimePassed()) <= setOffset))
 		{
 			return NULL;
 		}
-		return  ThisCall<void*>(0xAD8FD0, sound, offset);
+		return  ThisCall<void*>(0xAD8FD0, pSound, bDoRewind ? setOffset : offset);
+	}
+	void* __fastcall hk_QueryRadioSkipUpdatePipboy(BSSoundHandle* pSound, void* edx, unsigned int offset)
+	{
+
+		return  hk_QueryRadioSkipUpdate(pSound, offset, true);
+	}
+	void* __fastcall hk_QueryRadioSkipUpdatePlaced(BSSoundHandle* pSound, void* edx, unsigned int offset)
+	{
+		auto* _ebp = GetParentBasePtr(_AddressOfReturnAddress(), false);
+		char* path = reinterpret_cast<char*>(_ebp - 0x17C);
+		bool doRewind = strstr(path, ".mp3") == NULL; //the entire issue is the seek code assumes mp3
+		auto toRet = hk_QueryRadioSkipUpdate(pSound, offset, doRewind);
+		return toRet;
 	}
 
+	void* __cdecl hk_AllowOGGPlayBackFilepath(char* pPath, const char* pConstantWAV)
+	{
+		//Radios can actually play OGG directly... but the code only checks for WAV, although later it checks and if it doesn't find a wav, it falls back to an OGG.
+		//This leads to the hacky workaround where you must specify the file path as .wav even though it's an OGG.
+		auto toRet = strstr(pPath, pConstantWAV);
+		if (!toRet) { toRet = strstr(pPath, ".ogg"); }
+		return toRet;
+	}
 
+	void Install() 
+	{
 
-	void Install() {
-
-		WriteRelCall(0x834749, (uint32_t)hk_QueueRadioSkipUpdate);
-		WriteRelCall(0x8337F7, (uint32_t)hk_QueryRadioSkipUpdatePipboy);
+		WriteRelCall(0x8337F7, (uintptr_t)hk_QueryRadioSkipUpdatePipboy);
+		WriteRelCall(0x8354CC, (uintptr_t)hk_QueryRadioSkipUpdatePlaced);
+		WriteRelCall(0x833680, (uintptr_t)hk_AllowOGGPlayBackFilepath);
 
 	}
 

--- a/JG/internal/JG/RadioSkipOGGWAVPatch.cpp
+++ b/JG/internal/JG/RadioSkipOGGWAVPatch.cpp
@@ -10,37 +10,37 @@ namespace RadioSkipOGGWAVPatch {
 		return ThisCall<unsigned int>(0x63D040, pBSWin32Audio);
 
 	}
-	void* hk_QueryRadioSkipUpdate(BSSoundHandle* pSound, unsigned int offset, bool bDoRewind)
+	void* hk_QueryRadioSkipUpdate(BSSoundHandle* pSound, unsigned int iOffset, bool bDoRewind)
 	{
-		unsigned int msToRewind = 50; //the default value added by the game to skip
-		unsigned int setOffset = offset - msToRewind;
-		if (bDoRewind && ((BSWin32Audio_GetTimePassed()) <= setOffset))
+		unsigned int lMsToRewind = 50; //the default value added by the game to skip
+		unsigned int lRewindedOffset = iOffset - lMsToRewind;
+		if (bDoRewind && ((BSWin32Audio_GetTimePassed()) <= iOffset))
 		{
 			return NULL;
 		}
-		return  ThisCall<void*>(0xAD8FD0, pSound, bDoRewind ? setOffset : offset);
+		return  ThisCall<void*>(0xAD8FD0, pSound, iOffset);
 	}
-	void* __fastcall hk_QueryRadioSkipUpdatePipboy(BSSoundHandle* pSound, void* edx, unsigned int offset)
+	void* __fastcall hk_QueryRadioSkipUpdatePipboy(BSSoundHandle* pSound, void* _EDX, unsigned int iOffset)
 	{
 
-		return  hk_QueryRadioSkipUpdate(pSound, offset, true);
+		return  hk_QueryRadioSkipUpdate(pSound, iOffset, true);
 	}
-	void* __fastcall hk_QueryRadioSkipUpdatePlaced(BSSoundHandle* pSound, void* edx, unsigned int offset)
+	void* __fastcall hk_QueryRadioSkipUpdatePlaced(BSSoundHandle* pSound, void* _EDX, unsigned int iOffset)
 	{
 		auto* _ebp = GetParentBasePtr(_AddressOfReturnAddress(), false);
-		char* path = reinterpret_cast<char*>(_ebp - 0x17C);
-		bool doRewind = strstr(path, ".mp3") == NULL; //the entire issue is the seek code assumes mp3
-		auto toRet = hk_QueryRadioSkipUpdate(pSound, offset, doRewind);
-		return toRet;
+		char* lSoundPath = reinterpret_cast<char*>(_ebp - 0x17C);
+		//undo seek for ogg/wav
+		bool doRewind = (strstr(lSoundPath, ".ogg") != NULL) || (strstr(lSoundPath, ".wav") != NULL);
+		return hk_QueryRadioSkipUpdate(pSound, iOffset, doRewind);
 	}
 
 	void* __cdecl hk_AllowOGGPlayBackFilepath(char* pPath, const char* pConstantWAV)
 	{
 		//Radios can actually play OGG directly... but the code only checks for WAV, although later it checks and if it doesn't find a wav, it falls back to an OGG.
 		//This leads to the hacky workaround where you must specify the file path as .wav even though it's an OGG.
-		auto toRet = strstr(pPath, pConstantWAV);
-		if (!toRet) { toRet = strstr(pPath, ".ogg"); }
-		return toRet;
+		auto retVal = strstr(pPath, pConstantWAV);
+		if (!retVal) { retVal = strstr(pPath, ".ogg"); }
+		return retVal;
 	}
 
 	void Install() 


### PR DESCRIPTION
## Overview
This PR patches known issues regarding radio playback when using formats outside MP3. 

### The following patches have been applied:
* Fix OGG being unable to play in radios unless the path was specified as WAV (paradoxically)
* Fix OGG/WAV playing with their first hundred ms cut off (MP3 comes built in with some empty space, and the game accounted for this, but it applied it on OGG/WAV too)