### PR TITLE
NiFixedString map rewrite

### DIFF
--- a/JG/JohnnyGuitarNVSE.cpp
+++ b/JG/JohnnyGuitarNVSE.cpp
@@ -37,6 +37,7 @@
 #include <JG/DisabledArrowKeys.hpp>
 #include <JG/ExtraMiscStats.hpp>
 #include <JG/TaskQueue.hpp>
+#include <JG/FixedStringsRework.hpp>
 #include <events/LambdaVariableContext.h>
 #include <decoding.h>
 #include <misc/WorldToScreen.h>
@@ -72,8 +73,7 @@ bool (*Cmd_Update3D)(COMMAND_ARGS) = 0;
 #define REG_TYPED_CMD(name, type) nvse->RegisterTypedCommand(&kCommandInfo_##name,kRetnType_##type);
 
 void MessageHandler(NVSEMessagingInterface::Message* msg) {
-	MEM_CONTEXT eOrgContext = GetMemContext();
-	SetMemContext(MC_DEFAULT);
+	MEMORY_CONTEXT(MC_DEFAULT);
 	switch (msg->type) {
 		case NVSEMessagingInterface::kMessage_PostPostLoad: // GAME + GECK
 		{
@@ -112,6 +112,11 @@ void MessageHandler(NVSEMessagingInterface::Message* msg) {
 			noHolotapeStopSound = false;
 			break;
 		}
+		case NVSEMessagingInterface::kMessage_PostLoadGame: // GAME
+		{
+			NiGlobalStringTable::RemoveUnusedStrings();
+			break;
+		}
 		case NVSEMessagingInterface::kMessage_MainGameLoop: // GAME
 		{
 			TaskQueue::ExecuteTasks();
@@ -128,6 +133,7 @@ void MessageHandler(NVSEMessagingInterface::Message* msg) {
 			g_initialTickCount = GetTickCount();
 			Console_Print("JohnnyGuitar version: %.2f", ((float)JG_VERSION / 100));
 			EDIDRestoration::PrintErrors();
+			NiGlobalStringTable::RemoveUnusedStrings();
 			if (JohnnyPatches::bFixJIP)
 				JIPFixes::InitDeferredHooks();
 
@@ -145,7 +151,6 @@ void MessageHandler(NVSEMessagingInterface::Message* msg) {
 		default:
 			break;
 	}
-	SetMemContext(eOrgContext);
 }
 
 void MessageHandlerGECK(NVSEMessagingInterface::Message* msg) {
@@ -591,25 +596,25 @@ EXTERN_DLL_EXPORT bool NVSEPlugin_Load(const NVSEInterface* nvse) {
 	}
 
 	if (!bIsGECK) {
+		FixedStringsRework::Init();
+
+		NVSEDataInterface* nvseData = static_cast<NVSEDataInterface*>(nvse->QueryInterface(kInterface_Data));
+		JohnnyExtraData::InitName();
+		JohnnyExtraData::Initialize(nvseData);
+
+		InventoryRefGetForID = static_cast<InventoryRef * (*)(uint32_t)>(nvseData->GetFunc(NVSEDataInterface::kNVSEData_InventoryReferenceGetForRefID));
+		CaptureLambdaVars = static_cast<_CaptureLambdaVars>(nvseData->GetFunc(NVSEDataInterface::kNVSEData_LambdaSaveVariableList));
+		UncaptureLambdaVars = static_cast<_UncaptureLambdaVars>(nvseData->GetFunc(NVSEDataInterface::kNVSEData_LambdaUnsaveVariableList));
+		ExtractArgsEx = g_scriptInterface->ExtractArgsEx;
+
 		JGGameCamera.WorldMatrx = new JGWorldToScreenMatrix;
 		JGGameCamera.CamPos = new JGCameraPosition;
 		DisabledSaves::Init();
 		CustomHUDShake::Init();
-
-		if (JohnnyPatches::bFixJIP) {
-			JohnnyExtraData::InitName();
-		}
-
-		NVSEDataInterface* nvseData = static_cast<NVSEDataInterface*>(nvse->QueryInterface(kInterface_Data));
-		JohnnyExtraData::Initialize(nvseData);
-		InventoryRefGetForID = static_cast<InventoryRef * (*)(uint32_t)>(nvseData->GetFunc(NVSEDataInterface::kNVSEData_InventoryReferenceGetForRefID));
-		CaptureLambdaVars = static_cast<_CaptureLambdaVars>(nvseData->GetFunc(NVSEDataInterface::kNVSEData_LambdaSaveVariableList));
-		UncaptureLambdaVars = static_cast<_UncaptureLambdaVars>(nvseData->GetFunc(NVSEDataInterface::kNVSEData_LambdaUnsaveVariableList));
 		JohnnyFixes::Install();
 		JohnnyPatches::Install();
 		JohnnyGameSettings::Init();
 		JohnnyEvents::Install();
-		ExtractArgsEx = g_scriptInterface->ExtractArgsEx;
 		Serialization::Init(nvse);
 	}
 

--- a/JG/internal/Game/Bethesda/AutoMemContext.cpp
+++ b/JG/internal/Game/Bethesda/AutoMemContext.cpp
@@ -1,4 +1,5 @@
 #include "AutoMemContext.hpp"
+#include "TLSData.hpp"
 
 // GAME - 0x404EB0
 AutoMemContext::AutoMemContext(MEM_CONTEXT aeMemContext, bool abOverridable, const char* apFile, uint32_t auiLine) {
@@ -23,10 +24,10 @@ void AutoMemContext::Leave() const {
 
 // GAME - 0x404F50
 MEM_CONTEXT GetMemContext() {
-	return CdeclCall<MEM_CONTEXT>(0x404F50);
+	return static_cast<MEM_CONTEXT>(TLSData::GetMemContext());
 }
 
 // GAME - 0x404F30
 void SetMemContext(MEM_CONTEXT aeMemContext) {
-	return CdeclCall(0x404F30, aeMemContext);
+	TLSData::SetMemContext(aeMemContext);
 }

--- a/JG/internal/Game/Bethesda/TLSData.cpp
+++ b/JG/internal/Game/Bethesda/TLSData.cpp
@@ -1,0 +1,28 @@
+#include "TLSData.hpp"
+
+struct _TEB {
+	uint32_t		 padding[11];
+	struct TLSData** ThreadLocalStoragePointer;
+};
+
+TLSData* TLSData::Get() {
+#ifdef GAME
+	return NtCurrentTeb()->ThreadLocalStoragePointer[*reinterpret_cast<uint32_t*>(0x126FD98)];
+#else
+	return NtCurrentTeb()->ThreadLocalStoragePointer[*reinterpret_cast<uint32_t*>(0xF9879C)];
+#endif
+}
+
+// GAME - 0x404F50
+uint32_t TLSData::GetMemContext() {
+	return Get()->eMemContext;
+}
+
+// GAME - 0x404F30
+void TLSData::SetMemContext(uint32_t index) {
+	Get()->eMemContext = index;
+}
+
+uint32_t TLSData::GetBatchRendererIndex() {
+	return Get()->iBatchRendererIndex;
+}

--- a/JG/internal/Game/Bethesda/TLSData.hpp
+++ b/JG/internal/Game/Bethesda/TLSData.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+struct TLSData {
+	uint32_t							start_padding[2];
+#ifdef GAME
+	const class BaseExtraList* const	pLastExtraList;				// BaseExtraList
+	uint32_t							uiThreadDirty;				// BaseExtraList
+	class BSExtraData*					pLastExtraDatas[0x93];		// BaseExtraList
+	bool								bLoadTexturesDegraded;		// ModelLoader
+	bool								bLoadingTempCellData;		// TESObjectCELL
+	class NiAVObject*					pBackgroundLoading3D;		// TESObjectREFR
+	class TESObjectREFR*				pBackgroundLoadingRef;		// TESObjectREFR
+	bool								bConsoleOutput;				// Script
+	class TESForm*						pCrimeVictim;				// Script
+	class SCRIPT_LOCAL*					pLastVar;					// ScriptLocals
+	uint32_t							uiLastVarSearchID;			// ScriptLocals
+	class ScriptLocals*					pLastVarSearchScriptLocals;	// ScriptLocals
+	class SCRIPT_REFERENCED_OBJECT*		pLastRefObject;				// Script
+	uint32_t							uiLastRefSearchIndex;		// Script
+	class ScriptLocals*					pLastScriptLocals;			// Script
+	class Script*						pLastRefSearchScript;		// Script
+	uint32_t							uiActivateRecursionDepth;
+	uint32_t							unk290;
+	Bitfield32							uiThreadSpecificFlags;		// BGSSaveLoadGame
+	bool								bCollectGarbage;			// GarbageCollector
+	uint32_t							unk29C;
+	float								fLastScaledTime;
+	uint32_t							eLastCycle;
+	float								fLastWeightedPhaseTime;
+	float								fLastLoKeyTime;
+	float								fLastHiKeyTime;
+	uint32_t							eMemContext;
+	int32_t								iWarningCount;				// BSCoreMessage
+	int32_t								iBatchRendererIndex;		// BSShaderAccumulator
+    uint32_t							eHavokSyncMode;				// bhkNiCollisionObject
+#else
+	class ExtraDataList*				pLastExtraList;
+	uint32_t							uiThreadDirty;
+	class BSExtraData*					pLastExtraDatas[147];
+	bool								bLoadTexturesDegraded;
+	bool								unk25C;
+	bool								unk25D;
+	bool								unk25E;
+	bool								bConsoleOutput;
+	uint32_t							unk264;
+	bool								bLoadingTempCellData;
+	class NiNode*						pBackgroundLoading3D;
+	class TESObjectREFR*				pBackgroundLoadingRef;
+	uint32_t							unk274;
+	uint32_t							unk278;
+	uint32_t							unk27C;
+	uint32_t							unk280;
+	uint32_t							unk284;
+	uint32_t							unk288;
+	uint32_t							unk28C;
+	uint32_t							eMemContext; // 290
+	uint32_t							iWarningCount;
+	uint32_t							iBatchRendererIndex;
+	uint32_t							eHavokSyncMode;
+	uint32_t							unk2A0;
+	uint32_t							unk2A4;
+#endif
+
+	static TLSData* Get();
+
+	static uint32_t GetMemContext();
+	static void SetMemContext(uint32_t index);
+
+	static uint32_t GetBatchRendererIndex();
+
+};
+#ifdef GAME
+ASSERT_SIZE(TLSData, 0x2C4);
+#endif

--- a/JG/internal/Game/Gamebryo/NiFixedString.cpp
+++ b/JG/internal/Game/Gamebryo/NiFixedString.cpp
@@ -1,42 +1,43 @@
 #include "NiFixedString.hpp"
 #include "NiGlobalStringTable.hpp"
 
-NiFixedString::NiFixedString() {
+NiFixedString::NiFixedString() noexcept {
 	m_kHandle = nullptr;
 }
 
 // GAME - 0x438170
 // GECK - 0x43D6B0
-NiFixedString::NiFixedString(const char* apcString) {
-	if (apcString)
-		m_kHandle = NiGlobalStringTable::AddString(apcString);
+NiFixedString::NiFixedString(const char* apString) noexcept {
+	if (apString)
+		m_kHandle = NiGlobalStringTable::AddString(apString);
 	else
 		m_kHandle = nullptr;
 }
 
-NiFixedString::NiFixedString(const NiFixedString& arString) {
+NiFixedString::NiFixedString(const NiFixedString& arString) noexcept {
 	NiGlobalStringTable::IncRefCount(const_cast<NiGlobalStringTable::GlobalStringHandle&>(arString.m_kHandle));
 	m_kHandle = arString.m_kHandle;
 }
 
 // GAME - 0x4381B0
 // GECK - 0x43D6E0
-NiFixedString::~NiFixedString() {
+NiFixedString::~NiFixedString() noexcept {
 	NiGlobalStringTable::DecRefCount(m_kHandle);
 }
 
 // GAME - 0xA2E750
 // GECK - 0x7D8020
-NiFixedString& NiFixedString::operator=(const char* apcString) {
-	if (m_kHandle != apcString) {
+NiFixedString& NiFixedString::operator=(const char* apString) noexcept {
+	if (m_kHandle != apString) {
 		NiGlobalStringTable::GlobalStringHandle kHandle = m_kHandle;
-		m_kHandle = NiGlobalStringTable::AddString(apcString);
+		m_kHandle = NiGlobalStringTable::AddString(apString);
 		NiGlobalStringTable::DecRefCount(kHandle);
 	}
 	return *this;
 }
 
-NiFixedString& NiFixedString::operator=(const NiFixedString& arString) {
+// GAME - 0x43BA10
+NiFixedString& NiFixedString::operator=(const NiFixedString& arString) noexcept {
 	if (m_kHandle != arString.m_kHandle) {
 		NiGlobalStringTable::GlobalStringHandle kHandle = arString.m_kHandle;
 		NiGlobalStringTable::IncRefCount(kHandle);
@@ -46,15 +47,17 @@ NiFixedString& NiFixedString::operator=(const NiFixedString& arString) {
 	return *this;
 }
 
-NiFixedString::operator const char* () const {
+// GAME - 0x43B1B0
+NiFixedString::operator const char* () const noexcept {
 	return m_kHandle;
 }
 
-NiFixedString::operator bool() const {
+// GAME - 0x48AF70
+NiFixedString::operator bool() const noexcept {
 	return m_kHandle != nullptr;
 }
 
-const char* NiFixedString::c_str() const {
+const char* NiFixedString::c_str() const noexcept {
 	return m_kHandle;
 }
 
@@ -62,37 +65,39 @@ NiFixedString::operator std::basic_string_view<char>() const noexcept {
 	return { m_kHandle, GetLength() }; 
 }
 
-uint32_t NiFixedString::GetLength() const {
+uint32_t NiFixedString::GetLength() const noexcept {
 	return NiGlobalStringTable::GetLength(m_kHandle);
 }
 
-bool NiFixedString::Includes(const char* apToFind) const {
+bool NiFixedString::Includes(const char* apToFind) const noexcept {
 	if (!m_kHandle || !apToFind)
 		return false;
 
 	return strstr(m_kHandle, apToFind) != nullptr;
 }
 
-bool operator==(const NiFixedString& arString1, const NiFixedString& arString2) {
+bool operator==(const NiFixedString& arString1, const NiFixedString& arString2) noexcept {
 	return arString1.m_kHandle == arString2.m_kHandle;
 }
 
-bool operator==(const NiFixedString& arString, const char* apcString) {
-	if (arString.m_kHandle == apcString)
+// GAME - 0xA305E0
+// GECK - 0x7D8060
+bool operator==(const NiFixedString& arString, const char* apString) noexcept {
+	if (arString.m_kHandle == apString)
 		return true;
 
-	if (!arString.m_kHandle || !apcString)
+	if (!arString.m_kHandle || !apString)
 		return false;
 
-	return !strcmp(arString.m_kHandle, apcString);
+	return !strcmp(arString.m_kHandle, apString);
 }
 
-bool operator==(const char* apcString, const NiFixedString& arString) {
-	if (arString.m_kHandle == apcString)
+bool operator==(const char* apString, const NiFixedString& arString) noexcept {
+	if (arString.m_kHandle == apString)
 		return true;
 
-	if (!arString.m_kHandle || !apcString)
+	if (!arString.m_kHandle || !apString)
 		return false;
 
-	return !strcmp(arString.m_kHandle, apcString);
+	return !strcmp(arString.m_kHandle, apString);
 }

--- a/JG/internal/Game/Gamebryo/NiFixedString.hpp
+++ b/JG/internal/Game/Gamebryo/NiFixedString.hpp
@@ -5,30 +5,30 @@
 
 class SPEC_EMPTY_BASES NiFixedString : public NiMemObject {
 public:
-	NiFixedString();
-	NiFixedString(const char* apcString);
-	NiFixedString(const NiFixedString& arString);
-	~NiFixedString();
+	NiFixedString() noexcept;
+	NiFixedString(const char* apString) noexcept;
+	NiFixedString(const NiFixedString& arString) noexcept;
+	~NiFixedString() noexcept;
 
 	NiGlobalStringTable::GlobalStringHandle m_kHandle;
 
-	NiFixedString& operator=(const char* apcString);
-	NiFixedString& operator=(const NiFixedString& arString);
-	friend bool operator==(const NiFixedString& arString1, const NiFixedString& arString2);
-	friend bool operator==(const NiFixedString& arString, const char* apcString);
-	friend bool operator==(const char* apcString, const NiFixedString& arString);
+	NiFixedString& operator=(const char* apString) noexcept;
+	NiFixedString& operator=(const NiFixedString& arString) noexcept;
+	friend bool operator==(const NiFixedString& arString1, const NiFixedString& arString2) noexcept;
+	friend bool operator==(const NiFixedString& arString, const char* apString) noexcept;
+	friend bool operator==(const char* apString, const NiFixedString& arString) noexcept;
 
-	operator const char*() const;
+	operator const char*() const noexcept;
 
-	operator bool() const;
+	operator bool() const noexcept;
 
-	const char* c_str() const;
+	const char* c_str() const noexcept;
 
 	operator std::basic_string_view<char>() const noexcept;
 
-	uint32_t GetLength() const;
+	uint32_t GetLength() const noexcept;
 
-	bool Includes(const char* apToFind) const;
+	bool Includes(const char* apToFind) const noexcept;
 };
 
 ASSERT_SIZE(NiFixedString, 0x4)

--- a/JG/internal/Game/Gamebryo/NiGlobalStringTable.cpp
+++ b/JG/internal/Game/Gamebryo/NiGlobalStringTable.cpp
@@ -2,32 +2,42 @@
 
 // GAME - 0xA5B690
 // GECK - 0x81B0C0
-NiGlobalStringTable::GlobalStringHandle NiGlobalStringTable::AddString(const char* pcString) {
+NiGlobalStringTable::GlobalStringHandle NiGlobalStringTable::AddString(const char* apString) noexcept {
 #ifdef GAME
-    return CdeclCall<GlobalStringHandle>(0xA5B690, pcString);
+    return CdeclCall<GlobalStringHandle>(0xA5B690, apString);
 #else
-	return CdeclCall<GlobalStringHandle>(0x81B0C0, pcString);
+	return CdeclCall<GlobalStringHandle>(0x81B0C0, apString);
+#endif
+}
+
+// GAME - 0xA5B460
+// GECK - 0x81AF10
+void NiGlobalStringTable::RemoveUnusedStrings() noexcept {
+#ifdef GAME
+    CdeclCall(0xA5B460);
+#else
+    CdeclCall(0x81AF10);
 #endif
 }
 
 // GAME - 0x43BA60
-void NiGlobalStringTable::IncRefCount(GlobalStringHandle& arHandle) {
-    if (!arHandle)
+void NiGlobalStringTable::IncRefCount(GlobalStringHandle& arHandle) noexcept {
+    if (!arHandle) [[unlikely]]
         return;
 
-    InterlockedIncrement((size_t*)GetRealBufferStart(arHandle));
+    InterlockedIncrement(reinterpret_cast<size_t*>(GetRealBufferStart(arHandle)));
 }
 
 // GAME - 0x4381D0
-void NiGlobalStringTable::DecRefCount(GlobalStringHandle& arHandle) {
-    if (!arHandle)
+void NiGlobalStringTable::DecRefCount(GlobalStringHandle& arHandle) noexcept {
+    if (!arHandle) [[unlikely]]
         return;
 
-    InterlockedDecrement((size_t*)GetRealBufferStart(arHandle));
+    InterlockedDecrement(reinterpret_cast<size_t*>(GetRealBufferStart(arHandle)));
 }
 
-uint32_t NiGlobalStringTable::GetLength(const GlobalStringHandle& arHandle) {
-    if (!arHandle)
+uint32_t NiGlobalStringTable::GetLength(const GlobalStringHandle& arHandle) noexcept {
+    if (!arHandle) [[unlikely]]
 		return 0;
 
 	size_t* pBuffer = reinterpret_cast<size_t*>(GetRealBufferStart(arHandle));
@@ -35,6 +45,6 @@ uint32_t NiGlobalStringTable::GetLength(const GlobalStringHandle& arHandle) {
 }
 
 // GAME - 0x438210
-char* NiGlobalStringTable::GetRealBufferStart(const GlobalStringHandle& arHandle) {
-    return ((char*)arHandle - 2 * sizeof(size_t));
+char* NiGlobalStringTable::GetRealBufferStart(const GlobalStringHandle& arHandle) noexcept {
+    return (static_cast<char*>(arHandle) - 2 * sizeof(size_t));
 }

--- a/JG/internal/Game/Gamebryo/NiGlobalStringTable.hpp
+++ b/JG/internal/Game/Gamebryo/NiGlobalStringTable.hpp
@@ -9,7 +9,7 @@
 
 class NiFixedString;
 
-// Replaced by JIP
+// Replaced by JIP and JG
 class SPEC_EMPTY_BASES NiGlobalStringTable : public NiMemObject {
 public:
 	typedef char* GlobalStringHandle;
@@ -19,12 +19,22 @@ public:
 	NiCriticalSection						m_kCriticalSection;
 #endif
 
-	static GlobalStringHandle AddString(const char* pcString);
-	static void IncRefCount(GlobalStringHandle& arHandle);
-	static void DecRefCount(GlobalStringHandle& arHandle);
-	static uint32_t GetLength(const GlobalStringHandle& arHandle);
+#ifdef GAME
+	static constexpr AddressPtr<uint32_t, 0x11F42C4> uiTotalStrings;
+	static constexpr AddressPtr<uint32_t, 0x11F42C8> uiTotalCollisions;
+#else
+	static constexpr AddressPtr<uint32_t, 0xF20174> uiTotalStrings;
+	static constexpr AddressPtr<uint32_t, 0xF20178> uiTotalCollisions;
+#endif
 
-	static char* GetRealBufferStart(const GlobalStringHandle& arHandle);
+	static GlobalStringHandle AddString(const char* apString) noexcept;
+	static void RemoveUnusedStrings() noexcept;
+
+	static void IncRefCount(GlobalStringHandle& arHandle) noexcept;
+	static void DecRefCount(GlobalStringHandle& arHandle) noexcept;
+	static uint32_t GetLength(const GlobalStringHandle& arHandle) noexcept;
+
+	static char* GetRealBufferStart(const GlobalStringHandle& arHandle) noexcept;
 };
 
 #if !JIP_CHANGES

--- a/JG/internal/JG/FixedStringsRework.cpp
+++ b/JG/internal/JG/FixedStringsRework.cpp
@@ -1,0 +1,485 @@
+#include "FixedStringsRework.hpp"
+#include "JIP/JIPUtils.hpp"
+#include "Utilities.h"
+
+#include "Bethesda/AutoMemContext.hpp"
+#include "Gamebryo/NiGlobalStringTable.hpp"
+
+#include "shared/BSMemory/BSMemory.hpp"
+#include "shared/BSMemory/BSScrapMemory.hpp"
+
+#include <vector>
+#include <algorithm>
+#include <execution>
+#include <span>
+
+#pragma optimize("y", on)
+#pragma warning(disable: 4200)
+
+namespace FixedStringsRework {
+
+#define FIXED_STRING_DEBUG 0
+#define FIXED_STRING_ASYNC_CLEANUP 0
+
+	class ALIGN16 String {
+		volatile mutable uint32_t	uiRefCount;
+		uint32_t					uiLength;
+		char						cText[];
+
+		String() = delete;
+		String(const String&) = delete;
+		String(String&&) = delete;
+		~String() = delete;
+
+		inline void __fastcall _Create(const std::string_view& arString) noexcept {
+			uiRefCount = 0;
+			uiLength = arString.length();
+			CopyString(arString.data());
+		}
+
+		inline void __fastcall CopyString(const char* apText) {
+			memcpy(cText, apText, uiLength);
+			cText[uiLength] = '\0';
+		}
+
+		// Both strings must have the same length
+		static constexpr bool __fastcall StringMatch(const char* __restrict apStr1, const char* __restrict apStr2) noexcept {
+			ASSUME_ASSERT(apStr1 && apStr2 && apStr1 != apStr2);
+			do {
+				if (*apStr1 != *apStr2)
+					return false;
+				apStr1++;
+				apStr2++;
+			} while (*apStr1);
+			return true;
+		}
+
+	public:
+		constexpr const char* GetText() const noexcept {
+			return cText;
+		}
+
+		constexpr uint32_t GetLength() const noexcept {
+			return uiLength;
+		}
+
+		constexpr uint32_t GetRefCount() const noexcept {
+			return uiRefCount;
+		}
+
+		inline bool IsDeleted() const noexcept {
+			uint32_t uiExpected = 0;
+			return InterlockedCompareExchange(&uiRefCount, 0, uiExpected) == uiExpected;
+		}
+
+		inline void IncRefCount() noexcept {
+			InterlockedIncrement(&uiRefCount);
+		}
+
+		// Returns the string pointer and increments the reference count.
+		[[nodiscard]] inline const char* Take() noexcept {
+			IncRefCount();
+			return cText;
+		}
+
+		constexpr bool __fastcall Match(const std::string_view& arString) const noexcept {
+			if (cText == arString.data()) [[unlikely]]
+				return true;
+
+			ASSUME_ASSERT(uiLength && arString.length());
+			if (uiLength == arString.length()) [[likely]] {
+				if (StringMatch(cText, arString.data())) [[likely]]
+					return true;
+			}
+
+#if FIXED_STRING_DEBUG
+			++NiGlobalStringTable::uiTotalCollisions;
+			_MESSAGE("Hash conflict - \"%s\" with \"%s\"", cText, arString.data());
+#endif
+			return false;
+		}
+
+		static constexpr uint32_t __fastcall GetMemorySize(uint32_t auiLength) noexcept {
+			static constexpr uint32_t uiAlignment = 4;
+
+			uint32_t uiAllocSize = sizeof(String);
+
+			if (auiLength >= sizeof(uint32_t) * 2) [[likely]] {
+				uiAllocSize += sizeof(char) + auiLength;
+				const uint32_t uiSpillover = uiAllocSize % uiAlignment;
+				if (uiSpillover != 0)
+					uiAllocSize += uiAlignment - uiSpillover;
+			}
+
+			return uiAllocSize;
+		}
+
+		static String* __fastcall Create(const std::string_view& arString) noexcept {
+			const uint32_t uiAllocSize = GetMemorySize(arString.length());
+			String* pString = static_cast<String*>(BSMemory::malloc(uiAllocSize));
+			pString->_Create(arString);
+			++NiGlobalStringTable::uiTotalStrings;
+			return pString;
+		};
+
+		static void __fastcall Destroy(String* apString) noexcept {
+			BSMemory::free(apString);
+			--NiGlobalStringTable::uiTotalStrings;
+		}
+
+		static String strEmptyString;
+	};
+
+	template<uint32_t INITIAL_SIZE>
+	class ALIGN16 StringArray {
+		struct StringEntry {
+			constexpr StringEntry() noexcept : uiHash(0), pString(nullptr) {};
+			constexpr StringEntry(uint32_t auiHash, String* apString) noexcept : uiHash(auiHash), pString(apString) {};
+			constexpr StringEntry(const StringEntry& arOther) noexcept : uiHash(arOther.uiHash), pString(arOther.pString) {};
+			constexpr StringEntry(StringEntry&& arOther) noexcept : uiHash(arOther.uiHash), pString(arOther.pString) { arOther.uiHash = 0; arOther.pString = nullptr; }
+			constexpr ~StringEntry() noexcept {}
+
+			uint32_t	uiHash;
+			String* 	pString;
+
+			constexpr void operator=(const StringEntry& arOther) noexcept {
+				uiHash = arOther.uiHash;
+				pString = arOther.pString;
+			}
+
+			constexpr void operator=(StringEntry&& arOther) noexcept {
+				uiHash = arOther.uiHash;
+				pString = arOther.pString;
+				arOther.uiHash = 0;
+				arOther.pString = nullptr;
+			}
+
+			constexpr operator const String* () const noexcept {
+				return pString;
+			}
+
+			constexpr operator String* () noexcept {
+				return pString;
+			}
+
+			constexpr const String* operator->() const noexcept {
+				return pString;
+			}
+
+			constexpr String* operator->() noexcept {
+				return pString;
+			}
+
+			constexpr bool __fastcall Match(const std::string_view& arString, uint32_t auiHash) const noexcept {
+				ASSUME_ASSERT(uiHash && auiHash);
+				if (uiHash != auiHash) [[likely]]
+					return false;
+
+				ASSUME_ASSERT(pString != nullptr);
+				if (!pString->Match(arString)) [[unlikely]]
+					return false;
+
+				return true;
+			}
+
+			constexpr uint32_t GetHash() const noexcept {
+				return uiHash;
+			}
+
+			const char* Take() const noexcept {
+				ASSUME_ASSERT(pString != nullptr);
+				return pString->Take();
+			}
+		};
+
+		std::vector<StringEntry>	kStrings;
+		mutable SRWLOCK				kLock = SRWLOCK_INIT;
+
+		const char* __fastcall GetString(const std::string_view& arString, uint32_t auiHash) const noexcept {
+			for (const StringEntry& rEntry : kStrings) {
+#if 0
+				if (rEntry.Match(arString, auiHash))
+					return rEntry.Take();
+#else
+				ASSUME_ASSERT(rEntry.GetHash() && auiHash);
+				if (rEntry.GetHash() == auiHash) [[unlikely]] {
+					ASSUME_ASSERT(rEntry.pString != nullptr);
+					if (rEntry.pString->Match(arString)) [[likely]]
+						return rEntry.Take();
+				}
+
+#endif
+			}
+
+			return nullptr;
+		}
+
+		const char* __fastcall CreateString(const std::string_view& arString, uint32_t auiHash) noexcept {
+			MEMORY_CONTEXT(MC_STRINGS);
+			StringEntry kNewEntry(auiHash, String::Create(arString));
+			kStrings.push_back(kNewEntry);
+			return kNewEntry.Take();
+		}
+
+		uint32_t __fastcall DestroyString(uint32_t auiIndex) noexcept {
+			String::Destroy(kStrings[auiIndex]);
+			kStrings[auiIndex] = kStrings.back();
+			kStrings.pop_back();
+			return auiIndex - 1;
+		}
+
+	public:
+		StringArray() noexcept {
+			MEMORY_CONTEXT(MC_STRINGS);
+			kStrings.reserve(INITIAL_SIZE);
+			kLock = SRWLOCK_INIT;
+		}
+
+		~StringArray() noexcept {
+			SRWUniqueLock kGuard(kLock);
+			for (StringEntry& rEntry : kStrings) {
+				String::Destroy(rEntry.pString);
+			}
+		}
+
+		const char* __fastcall GetOrCreateString(const std::string_view& arString, uint32_t auiHash) noexcept {
+			const char* pFoundString = nullptr;
+			// Retrieval happens more often than insertion, so let's gamble
+			if (TryAcquireSRWLockShared(&kLock)) [[likely]] {
+				pFoundString = GetString(arString, auiHash);
+				ReleaseSRWLockShared(&kLock);
+			}
+
+			if (!pFoundString) {
+				// Need to iterate again, bummer
+				SRWUniqueLock kGuard(kLock);
+				pFoundString = GetString(arString, auiHash);
+				if (!pFoundString)
+					pFoundString = CreateString(arString, auiHash);
+			}
+
+			return pFoundString;
+		}
+
+		void __fastcall FreeUnusedStrings() noexcept {
+			SRWUniqueLock kGuard(kLock);
+			for (uint32_t i = 0; i < kStrings.size();) {
+				if (kStrings[i]->IsDeleted()) {
+					i = DestroyString(i);
+				}
+				else {
+					++i;
+				}
+			}
+			
+			const uint32_t uiSize = kStrings.size();
+			const uint32_t uiCapacity = kStrings.capacity();
+			if (uiSize < uiCapacity / 2)
+				kStrings.shrink_to_fit();
+
+			std::sort(kStrings.begin(), kStrings.end(), [](String* a, String* b) {
+				if (a->GetRefCount() == b->GetRefCount()) {
+					return a->GetLength() < b->GetLength();
+				}
+				return a->GetRefCount() > b->GetRefCount();
+				});
+		}
+
+#if FIXED_STRING_DEBUG
+		uint32_t DumpInfo() noexcept {
+			SRWSharedLock kGuard(&kLock);
+			uint32_t uiMemoryUsage = kStrings.capacity() * (sizeof(StringEntry) + sizeof(String*));
+
+			for (const StringEntry& rEntry : kStrings) {
+				uiMemoryUsage += String::GetMemorySize(rEntry->GetLength());
+				_MESSAGE("	Hash: %08X | RefCount: %u | Length: %u | String: \"%s\"", rEntry.GetHash(), rEntry->GetRefCount(), rEntry->GetLength(), rEntry->GetText());
+			}
+			_MESSAGE("Capacity: %u | Total strings: %u | Memory Usage: %u bytes", kStrings.capacity(), kStrings.size(), uiMemoryUsage);
+
+			return uiMemoryUsage;
+		}
+#endif
+	};
+
+	template<uint32_t CONTAINER_SIZE>
+	using StringContainer = StringArray<CONTAINER_SIZE>;
+
+	template<uint32_t CONTAINER_COUNT, uint32_t CONTAINER_SIZE>
+	class FixedStringTable {
+#if FIXED_STRING_ASYNC_CLEANUP
+		HANDLE hBackgroundThread	= nullptr;
+		HANDLE hCleanupEvent		= nullptr;
+		HANDLE hThreadExitEvent		= nullptr;
+#endif
+		StringContainer<CONTAINER_SIZE> kContainers[CONTAINER_COUNT];
+
+		static inline String* pEmptyString = nullptr;
+
+		static constexpr uint32_t __fastcall GetStringHash(const std::string_view& arString) noexcept {
+			static constexpr std::hash<std::string_view> kStringHasher;
+			return kStringHasher(arString);
+		}
+
+		static constexpr uint32_t __fastcall GetContainerIndex(uint32_t auiHash) noexcept {
+			return auiHash % CONTAINER_COUNT;
+		}
+		
+		// TODO: Use BSTasklets for this instead of creating new threads
+		void __fastcall FreeUnusedStrings() noexcept {
+			const std::span<StringContainer<CONTAINER_SIZE>> kContSpan(kContainers, CONTAINER_COUNT);
+
+			std::for_each(std::execution::par, kContSpan.begin(), kContSpan.end(), [](StringContainer<CONTAINER_SIZE>& arCont) {
+				arCont.FreeUnusedStrings();
+				});
+		}
+
+		void __fastcall GarbageCollection() {
+#if FIXED_STRING_DEBUG
+			const uint32_t uiTotalStrings = NiGlobalStringTable::uiTotalStrings.Get();
+			FreeUnusedStrings();
+			const uint32_t uiFreedStrings = uiTotalStrings - NiGlobalStringTable::uiTotalStrings.Get();
+			_MESSAGE("Freed %u strings", uiFreedStrings);
+			DumpInfo();
+#else
+			FreeUnusedStrings();
+#endif
+		}
+
+	public:
+		FixedStringTable() noexcept {
+			pEmptyString = String::Create("");
+#if FIXED_STRING_ASYNC_CLEANUP
+			hBackgroundThread = CreateThread(nullptr, 0, [](void* apParam) -> DWORD {
+				FixedStringTable* pManager = static_cast<FixedStringTable*>(apParam);
+				HANDLE hEvents[2] = { pManager->hCleanupEvent, pManager->hThreadExitEvent };
+				while (true) {
+					DWORD dwWaitResult = WaitForMultipleObjects(2, hEvents, FALSE, INFINITE);
+					if (dwWaitResult == WAIT_OBJECT_0) {
+						pManager->GarbageCollection();
+						ResetEvent(pManager->hCleanupEvent);
+					}
+					else if (dwWaitResult == WAIT_OBJECT_0 + 1) {
+						break;
+					}
+				}
+				return 0;
+				}, this, 0, nullptr);
+
+			hCleanupEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+			hThreadExitEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+#endif
+		};
+		~FixedStringTable() noexcept {
+			String::Destroy(pEmptyString);
+#if FIXED_STRING_ASYNC_CLEANUP
+			if (hBackgroundThread) {
+				SetEvent(hThreadExitEvent);
+				WaitForSingleObject(hBackgroundThread, INFINITE);
+				CloseHandle(hBackgroundThread);
+			}
+
+			if (hCleanupEvent)
+				CloseHandle(hCleanupEvent);
+
+			if (hThreadExitEvent)
+				CloseHandle(hThreadExitEvent);
+#endif
+		}
+
+		const char* __fastcall GetString(const char* apString) noexcept {
+			if (!apString) [[unlikely]]
+				return nullptr;
+
+			if (apString[0] == '\0') [[unlikely]]
+				return pEmptyString->Take();
+
+			const std::string_view svString(apString);
+			const uint32_t uiHash = GetStringHash(svString);
+			const uint32_t uiContainer = GetContainerIndex(uiHash);
+			return kContainers[uiContainer].GetOrCreateString(svString, uiHash);
+		}
+
+		void __fastcall RequestStringCleanup() noexcept {
+#if FIXED_STRING_ASYNC_CLEANUP
+			SetEvent(hCleanupEvent);
+#else
+			GarbageCollection();
+#endif
+		}
+
+#if FIXED_STRING_DEBUG
+		void __fastcall DumpInfo() noexcept {
+			uint32_t uiSize = 0;
+			_MESSAGE("=== Fixed String Manager Info ===");
+			for (uint32_t i = 0; i < CONTAINER_COUNT; i++) {
+				_MESSAGE("\nContainer %i:", i);
+				uiSize += kContainers[i].DumpInfo();
+			}
+			_MESSAGE("\nTotal strings: %u", NiGlobalStringTable::uiTotalStrings.Get());
+			_MESSAGE("Total collisions: %u", NiGlobalStringTable::uiTotalCollisions.Get());
+			_MESSAGE("Memory usage: %u bytes", uiSize);
+			_MESSAGE("Empty string users: %u", pEmptyString->GetRefCount());
+		}
+#endif
+	};
+
+	namespace Data {
+		constexpr uint32_t STRING_MAP_COUNT = 1023;
+		constexpr uint32_t STRING_BUCKET_COUNT = 192;
+		using GlobalStringTable = FixedStringTable<STRING_MAP_COUNT, STRING_BUCKET_COUNT>;
+
+		static GlobalStringTable* pManager = nullptr;
+
+		static void Init() {
+#ifdef GAME
+			char* pMemManager = reinterpret_cast<char*>(0x11F6238);
+#else
+			char* pMemManager = reinterpret_cast<char*>(0xF21B5C);
+#endif
+			MEMORY_CONTEXT(MC_STATIC_VARS);
+			bool bOrgVal = pMemManager[129];
+			pMemManager[129] = false;
+			pManager = new GlobalStringTable();
+			pMemManager[129] = bOrgVal;
+		}
+	}
+
+	namespace Hooks {
+		static const char* __cdecl GetFixedString(const char* apString) noexcept {
+			return Data::pManager->GetString(apString);
+		}
+
+		static void __cdecl FreeUnusedFixedStrings() noexcept {
+			Data::pManager->RequestStringCleanup();
+		}
+
+		static void Init() {
+
+#ifdef GAME
+			SafeWrite8(0xA5B630, 0xC3);
+			WriteRelJump(0xA5B690, Hooks::GetFixedString);
+			WriteRelJump(0xA5B460, Hooks::FreeUnusedFixedStrings);
+#else
+			SafeWrite8(0x81B060, 0xC3);
+			WriteRelJump(0x81B0C0, Hooks::GetFixedString);
+			WriteRelJump(0x81AF10, Hooks::FreeUnusedFixedStrings);
+#endif
+
+			if (JIPUtils::IsValid()) {
+				PatchMemoryNopRange(JIPUtils::GetAddress(0x10012260), JIPUtils::GetAddress(0x1001228D));
+				WriteRelJump(JIPUtils::GetAddress(0x1000CE20), Hooks::GetFixedString);
+			}
+		}
+	}
+
+	void Init() {
+		Data::Init();
+		Hooks::Init();
+	}
+
+}
+
+#pragma warning(default: 4200)
+#pragma optimize("", on)
+
+#undef SCOPED_TIMER

--- a/JG/internal/JG/FixedStringsRework.hpp
+++ b/JG/internal/JG/FixedStringsRework.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace FixedStringsRework {
+	void Init();
+}

--- a/JG/internal/JIP/JIPFixes.cpp
+++ b/JG/internal/JIP/JIPFixes.cpp
@@ -1672,9 +1672,6 @@ namespace JIPFixes {
 		}
 	}
 
-		}
-	}
-
 	namespace LogMover {
 
 		void InitHooks() {

--- a/JG/internal/JIP/JIPFixes.cpp
+++ b/JG/internal/JIP/JIPFixes.cpp
@@ -1,26 +1,30 @@
 #include "JIPFixes.hpp"
-#include "Bethesda/BSStringT.hpp"
+#include "JIPSettings.hpp"
+#include "JIPUtils.hpp"
+
 #include "Bethesda/AutoMemContext.hpp"
 #include "Bethesda/Setting.hpp"
+#include "Bethesda/BSStringT.hpp"
+
+#include "decoding.h"
 #include "events/EventFramework.h"
-#include "GameObjects.h"
-#include "GameProcess.h"
-#include "GameTiles.h"
 #include "GameData.h"
-#include "GameRTTI.h"
+#include "GameObjects.h"
 #include "GameOSDepend.h"
-#include "JG/JohnnyExtraData.hpp"
+#include "GameProcess.h"
+#include "GameRTTI.h"
+#include "GameTiles.h"
 #include "ParamInfos.h"
 #include "PluginAPI.h"
 #include "utility.h"
-#include <decoding.h>
+
+#include "JG/JohnnyExtraData.hpp"
 #include "internal/CommandOpcodes.h"
 
 #include "Shared/BSMemory/BSScrapMemory.hpp"
 #include "Shared/Utils/StackObject.hpp"
 #include "Shared/Utils/CustomClass.hpp"
 
-#include <array>
 #include <GameUI.h>
 
 class BSRenderedTexture;
@@ -30,63 +34,9 @@ extern NVSEScriptInterface* g_scriptInterface;
 extern bool bFixJIP;
 extern bool bIsGECK;
 extern bool (*ExtractArgsEx)(COMMAND_ARGS_EX, ...);
-
-static HMODULE hJIP = 0;
-constexpr uint32_t CRC32_TABLE_SIZE = 256;
-constexpr uint32_t JIP_TARGET_HASH = 0x9DF36B6;
-constexpr uint32_t JIP_TARGET_SIZE = 502272;
-
-static size_t __fastcall GetJIPAddress(size_t aiAddress) {
-	return reinterpret_cast<size_t>(hJIP) + aiAddress - 0x10000000;
-}
-
-namespace JIPSettings {
-
-	bool IsSettingClear(const char* apSetting, const char* apPath) {
-		return GetPrivateProfileInt("JIP", apSetting, 1, apPath) == 0;
-	}
-
-	void InitConditionalHooks() {
-		char cFilename[MAX_PATH];
-		GetModuleFileNameA(NULL, cFilename, MAX_PATH);
-		char* pLastSlash = strrchr(cFilename, '\\') + 1;
-		uint32_t uiLength = MAX_PATH - (pLastSlash - cFilename);
-		strcpy_s(pLastSlash, uiLength, "Data\\nvse\\plugins\\JohnnyGuitar.ini");
-
-		if (IsSettingClear("bFixPositiveChemDuration", cFilename))
-			PatchMemoryNopRange(GetJIPAddress(0x100128C3), GetJIPAddress(0x100128E1));
-	}
-
-}
+extern InventoryRef* (*InventoryRefGetForID)(uint32_t auiFormID);
 
 namespace JIPFixes {
-
-	static constexpr std::array<uint32_t, CRC32_TABLE_SIZE> initCRC32Table() {
-		constexpr uint32_t polynomial = 0xEDB88320;
-		std::array<uint32_t, CRC32_TABLE_SIZE> crc32table;
-		for (uint32_t i = 0; i < CRC32_TABLE_SIZE; i++) {
-			uint32_t crc = i;
-			for (uint32_t j = 0; j < 8; j++) {
-				if (crc & 1)
-					crc = (crc >> 1) ^ polynomial;
-				else
-					crc >>= 1;
-			}
-			crc32table[i] = crc;
-		}
-		return crc32table;
-	}
-
-
-	static uint32_t crc32(const uint8_t* data, size_t length) {
-		constexpr std::array<uint32_t, CRC32_TABLE_SIZE> crc32table = initCRC32Table();
-		uint32_t crc = 0xFFFFFFFF;
-		for (size_t i = 0; i < length; i++) {
-			uint8_t byte = data[i];
-			crc = (crc >> 8) ^ crc32table[(crc ^ byte) & 0xFF];
-		}
-		return crc ^ 0xFFFFFFFF;
-	}
 
 	namespace ConsoleCmdFix {
 
@@ -108,7 +58,7 @@ namespace JIPFixes {
 		}
 
 		void InitHooks() {
-			SafeWrite32(GetJIPAddress(0x10059A86 + 1), uint32_t(ScriptCompiler_Compile));
+			SafeWrite32(JIPUtils::GetAddress(0x10059A86 + 1), uint32_t(ScriptCompiler_Compile));
 		}
 
 	}
@@ -145,7 +95,7 @@ namespace JIPFixes {
 		}
 
 		void InitHooks() {
-			kMemPoolFree.ReplaceCall(GetJIPAddress(0x1002BF45), MemoryPool_Free);
+			kMemPoolFree.ReplaceCall(JIPUtils::GetAddress(0x1002BF45), MemoryPool_Free);
 		}
 	}
 
@@ -347,7 +297,7 @@ namespace JIPFixes {
 		};
 
 		void InitHooks() {
-			const uint32_t uiJIPMessageDurationAddr = GetJIPAddress(0x1006A1B4);
+			const uint32_t uiJIPMessageDurationAddr = JIPUtils::GetAddress(0x1006A1B4);
 			for (uint32_t uiAddress : uiDefaultTimes)
 				SafeWrite32(uiAddress + 2, uiJIPMessageDurationAddr);
 
@@ -357,7 +307,7 @@ namespace JIPFixes {
 
 	namespace CloseActiveMenuFix {
 		void InitHooks() {
-			SafeWrite8(GetJIPAddress(0x1003B87B + 1), 0x7A);
+			SafeWrite8(JIPUtils::GetAddress(0x1003B87B + 1), 0x7A);
 		}
 	}
 
@@ -384,8 +334,8 @@ namespace JIPFixes {
 
 
 		void InitHooks() {
-			uiDoFireWeaponAddr = GetJIPAddress(0x1001B6F0);
-			SafeWrite32(GetJIPAddress(0x1001B827) + 4, uint32_t(DoFireWeaponExWrapper));
+			uiDoFireWeaponAddr = JIPUtils::GetAddress(0x1001B6F0);
+			SafeWrite32(JIPUtils::GetAddress(0x1001B827) + 4, uint32_t(DoFireWeaponExWrapper));
 
 			PatchMemoryNop(0x523B3F, 8);
 			WriteRelCallEx(0x523B3F, &ActorEx::GetCombatControllerEx);
@@ -395,7 +345,7 @@ namespace JIPFixes {
 	namespace ItemDescriptionFixFix {
 		const char* __fastcall ConstructItemEntryNameHookFix(TESBoundObject* apObject, uint32_t* arLength) {
 			*arLength = 0;
-			TESFullName* pFullName = DYNAMIC_CAST(apObject, TESBoundObject, TESFullName);
+			const TESFullName* pFullName = DYNAMIC_CAST(apObject, TESBoundObject, TESFullName);
 			if (!pFullName)
 				return nullptr;
 
@@ -428,10 +378,10 @@ namespace JIPFixes {
 		}
 
 		void InitHooks() {
-			uiFailAddr		= GetJIPAddress(0x1000DF10);
-			uiSuccessAddr	= GetJIPAddress(0x1000DECA);
-			WriteRelJump(GetJIPAddress(0x1000DEC2), ConstructItemEntryNameHookFix_Asm);
-			SafeWriteBuf(GetJIPAddress(0x1000DECC), "\x8D\x30\x90", 3); // Patch to use string from EAX instead of EAX+0x34
+			uiFailAddr		= JIPUtils::GetAddress(0x1000DF10);
+			uiSuccessAddr	= JIPUtils::GetAddress(0x1000DECA);
+			WriteRelJump(JIPUtils::GetAddress(0x1000DEC2), ConstructItemEntryNameHookFix_Asm);
+			SafeWriteBuf(JIPUtils::GetAddress(0x1000DECC), "\x8D\x30\x90", 3); // Patch to use string from EAX instead of EAX+0x34
 		}
 	}
 
@@ -470,49 +420,56 @@ namespace JIPFixes {
 		}
 
 		void InitHooks() {
-			ReplaceVirtualCall(GetJIPAddress(0x1000A09A), &Hook::UpdateTransformAndBounds);
-			ReplaceVirtualCall(GetJIPAddress(0x10019C7A), &Hook::UpdateDownwardPass);
+			ReplaceVirtualCall(JIPUtils::GetAddress(0x1000A09A), &Hook::UpdateTransformAndBounds);
+			ReplaceVirtualCall(JIPUtils::GetAddress(0x10019C7A), &Hook::UpdateDownwardPass);
 
-			ReplaceVirtualCall(GetJIPAddress(0x1002AE08), &Hook::UpdateDownwardPass);
-			ReplaceVirtualCall(GetJIPAddress(0x1002B07A), &Hook::UpdateDownwardPass);
-			ReplaceVirtualCall(GetJIPAddress(0x1002B18A), &Hook::UpdateDownwardPass);
+			ReplaceVirtualCall(JIPUtils::GetAddress(0x1002AE08), &Hook::UpdateDownwardPass);
+			ReplaceVirtualCall(JIPUtils::GetAddress(0x1002B07A), &Hook::UpdateDownwardPass);
+			ReplaceVirtualCall(JIPUtils::GetAddress(0x1002B18A), &Hook::UpdateDownwardPass);
 
-			ReplaceVirtualCall(GetJIPAddress(0x1002CE4D), &Hook::Update);
+			ReplaceVirtualCall(JIPUtils::GetAddress(0x1002CE4D), &Hook::Update);
 
-			ReplaceVirtualCall<2>(GetJIPAddress(0x1005887C), &Hook::UpdateDownwardPass);
-			ReplaceVirtualCall<2>(GetJIPAddress(0x10058927), &Hook::UpdateDownwardPass);
-			ReplaceVirtualCall<2>(GetJIPAddress(0x10058A7E), &Hook::UpdateDownwardPass);
+			ReplaceVirtualCall<2>(JIPUtils::GetAddress(0x1005887C), &Hook::UpdateDownwardPass);
+			ReplaceVirtualCall<2>(JIPUtils::GetAddress(0x10058927), &Hook::UpdateDownwardPass);
+			ReplaceVirtualCall<2>(JIPUtils::GetAddress(0x10058A7E), &Hook::UpdateDownwardPass);
 
-			ReplaceVirtualFuncEx(GetJIPAddress(0x100280FE + 1), &Hook::UpdateDownwardPass);
+			ReplaceVirtualFuncEx(JIPUtils::GetAddress(0x100280FE + 1), &Hook::UpdateDownwardPass);
 		}
 	}
 
 	namespace EarlyFixedStrings {
 
-		static uint32_t uiExitAddr = 0x1000CE06;
-		static uint32_t uiContinueAddr = 0x1000CDD5;
+		static uint32_t uiFoundStringAddr = 0x1000CE06;
+		static uint32_t uiNewStringAddr = 0x1000CDDB;
 
-		bool __fastcall StrCmp(const char* a, const char* b) {
-			if (a == b)
-				return true;
-
-			return strcmp(a, b) == 0;
+		int32_t __fastcall StrCmp(const char* a, const char* b) {
+			return strcmp(a, b);
 		}
 
 		void __declspec(naked) CompareFix_Asm() {
 			__asm {
+				START:
 				cmp		[eax + 4], esi
 				jnz		CONTINUE
 				push	eax
 				mov		edx, [ebp + 8]
 				mov		ecx, [eax + 8]
-				call	StrCmp
-				test	al, al
+				cmp		ecx, edx
+				jnz		FULL_COMPARE
 				pop		eax
-				jz		CONTINUE
-				jmp		uiExitAddr
+				jmp		MATCH
+				FULL_COMPARE:
+				call	StrCmp
+				test	eax, eax
+				pop		eax
+				jnz		CONTINUE
+				MATCH:
+				jmp		uiFoundStringAddr
 				CONTINUE:
-				jmp		uiContinueAddr
+				mov		eax, [eax]
+				test	eax, eax
+				jnz		START
+				jmp		uiNewStringAddr
 			}
 		}
 
@@ -522,30 +479,36 @@ namespace JIPFixes {
 		}
 
 		void InitHooks() {
-			uiExitAddr = GetJIPAddress(0x1000CE06);
-			uiContinueAddr = GetJIPAddress(0x1000CDD5);
-			WriteRelJump(GetJIPAddress(0x1000CDD0), CompareFix_Asm);
+			// Replaced by us now - see FixedStringsRework.cpp
+#if 0
+			uiFoundStringAddr = JIPUtils::GetAddress(0x1000CE06);
+			uiNewStringAddr = JIPUtils::GetAddress(0x1000CDDB);
+			WriteRelJump(JIPUtils::GetAddress(0x1000CDD0), CompareFix_Asm);
 			SafeWrite8(0xA5B630, 0xC3);
-			WriteRelJump(0xA5B690, GetJIPAddress(0x1000CE20));
-			WriteRelJump(0xA5B460, GetJIPAddress(0x1000CEA0));
-			PatchMemoryNopRange(GetJIPAddress(0x10012260), GetJIPAddress(0x1001228D));
+			WriteRelJump(0xA5B690, JIPUtils::GetAddress(0x1000CE20));
+			WriteRelJump(0xA5B460, JIPUtils::GetAddress(0x1000CEA0));
+			PatchMemoryNopRange(JIPUtils::GetAddress(0x10012260), JIPUtils::GetAddress(0x1001228D));
+
+			WriteRelJump(uint32_t(CompareFix_Asm) + 0x1D, uiFoundStringAddr);
+			WriteRelJump(uint32_t(CompareFix_Asm) + 0x29, uiNewStringAddr);
 
 			constexpr uint32_t BUCKET_SIZE = 4;
 			constexpr uint32_t NEW_BUCKET_COUNT = 8192;
 
-			SafeWrite32(GetJIPAddress(0x1000CD8E) + 1, NEW_BUCKET_COUNT * BUCKET_SIZE);
-			SafeWrite32(GetJIPAddress(0x1000CD9A) + 1, NEW_BUCKET_COUNT);
-			SafeWrite32(GetJIPAddress(0x1000CDBD) + 2, NEW_BUCKET_COUNT - 1);
+			SafeWrite32(JIPUtils::GetAddress(0x1000CD8E) + 1, NEW_BUCKET_COUNT * BUCKET_SIZE);
+			SafeWrite32(JIPUtils::GetAddress(0x1000CD9A) + 1, NEW_BUCKET_COUNT);
+			SafeWrite32(JIPUtils::GetAddress(0x1000CDBD) + 2, NEW_BUCKET_COUNT - 1);
 
-			SafeWrite32(GetJIPAddress(0x1000CEB4) + 2, NEW_BUCKET_COUNT * BUCKET_SIZE);
+			SafeWrite32(JIPUtils::GetAddress(0x1000CEB4) + 2, NEW_BUCKET_COUNT * BUCKET_SIZE);
 
-			ReplaceCall(GetJIPAddress(0x1000CD93), StaticAlloc);
+			ReplaceCall(JIPUtils::GetAddress(0x1000CD93), StaticAlloc);
+#endif
 		}
 	}
 
 	namespace PerkEntryFix {
 		void InitHooks() {
-			PatchMemoryNop(GetJIPAddress(0x1000F3F3), 6);
+			PatchMemoryNop(JIPUtils::GetAddress(0x1000F3F3), 6);
 		}
 	}
 
@@ -554,8 +517,8 @@ namespace JIPFixes {
 		bool(__cdecl* CopyFaceGenFrom)(COMMAND_ARGS) = nullptr;
 
 		bool Cmd_CopyFaceGenFrom_Execute(COMMAND_ARGS) {
-			bool bLoadFaceGenHeadEGTFilesOrg = *reinterpret_cast<bool*>(0x11D5AE0);
-			bool bResult = CopyFaceGenFrom(PASS_COMMAND_ARGS);
+			const bool bLoadFaceGenHeadEGTFilesOrg = *reinterpret_cast<bool*>(0x11D5AE0);
+			const bool bResult = CopyFaceGenFrom(PASS_COMMAND_ARGS);
 			*reinterpret_cast<bool*>(0x11D5AE0) = bLoadFaceGenHeadEGTFilesOrg;
 			return bResult;
 		}
@@ -590,7 +553,7 @@ namespace JIPFixes {
 	
 	}
 	namespace SetOnDialogTopicEventHandlerEx {
-
+#pragma optimize("y", off)
 		EventInformation* OnDialogTopicHandler = nullptr;
 
 		bool Cmd_SetOnDialogTopicEventHandler_JG_Execute(COMMAND_ARGS) {
@@ -621,7 +584,7 @@ namespace JIPFixes {
 				COUNT	= 2,
 			};
 
-#pragma optimize("y", off)
+
 			Script* GetResultScript(ResultScriptType aeScript) {
 				if (aeScript == ResultScriptType::BEGIN) {
 					uint8_t* pEBP = GetParentBasePtr(_AddressOfReturnAddress());
@@ -641,7 +604,6 @@ namespace JIPFixes {
 
 				return ThisCall<Script*>(kGetResultScript.GetOverwrittenAddr(), this, aeScript);
 			}
-#pragma optimize("", on)
 		};
 
 		void InitHooks() {
@@ -657,7 +619,7 @@ namespace JIPFixes {
 				}
 			}
 		}
-
+#pragma optimize("", on)
 	}
       
 	namespace RespawnDisableFix {
@@ -693,8 +655,8 @@ namespace JIPFixes {
 				pInfo->execute = Cmd_ClearDeadActors_Execute;
 
 				if (!bIsGECK) {
-					WriteRelCallEx(GetJIPAddress(0x10030C38), &HighProcessEx::FadeAndDisable);
-					PatchMemoryNop(GetJIPAddress(0x10030C3D), 2);
+					WriteRelCallEx(JIPUtils::GetAddress(0x10030C38), &HighProcessEx::FadeAndDisable);
+					PatchMemoryNop(JIPUtils::GetAddress(0x10030C3D), 2);
 				}
 			}
 		}
@@ -805,7 +767,7 @@ namespace JIPFixes {
 		}
 
 		void InitHooks() {
-			uiWeaponHasScope = GetJIPAddress(0x10058F10);
+			uiWeaponHasScope = JIPUtils::GetAddress(0x10058F10);
 			CommandInfo* pInfo = const_cast<CommandInfo*>(g_cmdTableInterface->GetByOpcode(CommandOpcodes::kReloadEquippedModels));
 			if (pInfo) {
 				pInfo->execute = Cmd_ReloadEquippedModels_Execute;
@@ -1110,12 +1072,13 @@ namespace JIPFixes {
 
 	namespace WeaponModEffectsFix {
 		void InitHooks() {
-			PatchMemoryNop(GetJIPAddress(0x1003DA30), 5);
-			SafeWrite8(GetJIPAddress(0x1003DA2B + 2), 0xF);
+			PatchMemoryNop(JIPUtils::GetAddress(0x1003DA30), 5);
+			SafeWrite8(JIPUtils::GetAddress(0x1003DA2B + 2), 0xF);
 		}
 	}
 
 	namespace OnMenuClickFix {
+#pragma optimize("y", off)
 		static inline Tile* const INVALID_TILE = reinterpret_cast<Tile*>(-1);
 		Tile* pClickedTile = INVALID_TILE;
 		uint32_t uiMenuHandleClickHook = 0;
@@ -1126,7 +1089,6 @@ namespace JIPFixes {
 			FastCall(uiMenuHandleClickHook, apMenu, edx, auiTileID, apTile);
 		}
 
-#pragma optimize("y", off)
 		bool __cdecl CallFunctionAlt(Script* apScript, TESObjectREFR* apRef, uint8_t aucArgCount, uint32_t auiMenuID, uint32_t auiTileID, const char* apTileString) {
 			uint8_t* pEBP = GetParentBasePtr(_AddressOfReturnAddress());
 			if (pClickedTile == INVALID_TILE) {
@@ -1139,13 +1101,12 @@ namespace JIPFixes {
 				return false;
 			}
 			else if (pClickedTile) {
-				return g_scriptInterface->CallFunctionAlt(apScript, apRef, aucArgCount, auiMenuID, auiTileID, pClickedTile->name.GetString());
+				return g_scriptInterface->CallFunctionAlt(apScript, apRef, aucArgCount, auiMenuID, auiTileID, pClickedTile->name.c_str());
 			}
 			else {
 				return g_scriptInterface->CallFunctionAlt(apScript, apRef, aucArgCount, auiMenuID, auiTileID, cEmptyBuffer);
 			}
 		}
-#pragma optimize("", on)
 
 		CallDetour kRemoveTileFromUpdateList;
 		class Hook {
@@ -1159,20 +1120,21 @@ namespace JIPFixes {
 		};
 
 		void InitHooks() {
-			uiMenuHandleClickHook = GetJIPAddress(0x10008570);
-			SafeWrite32(GetJIPAddress(0x10039C8A) + 1, uint32_t(MenuHandleClickHookDetour));
-			SafeWrite32(GetJIPAddress(0x1003A008) + 1, uint32_t(MenuHandleClickHookDetour));
+			uiMenuHandleClickHook = JIPUtils::GetAddress(0x10008570);
+			SafeWrite32(JIPUtils::GetAddress(0x10039C8A) + 1, uint32_t(MenuHandleClickHookDetour));
+			SafeWrite32(JIPUtils::GetAddress(0x1003A008) + 1, uint32_t(MenuHandleClickHookDetour));
 
-			SafeWriteBuf(GetJIPAddress(0x10008683), "\x6A\x00\x90");
-			PatchMemoryNop(GetJIPAddress(0x10008693), 6);
-			WriteRelCall(GetJIPAddress(0x10008693), CallFunctionAlt);
+			SafeWriteBuf(JIPUtils::GetAddress(0x10008683), "\x6A\x00\x90");
+			PatchMemoryNop(JIPUtils::GetAddress(0x10008693), 6);
+			WriteRelCall(JIPUtils::GetAddress(0x10008693), CallFunctionAlt);
 
-			WriteRelJump(GetJIPAddress(0x1000872F), GetJIPAddress(0x1000873B));
-			PatchMemoryNop(GetJIPAddress(0x10008791), 6);
-			WriteRelCall(GetJIPAddress(0x10008791), CallFunctionAlt);
+			WriteRelJump(JIPUtils::GetAddress(0x1000872F), JIPUtils::GetAddress(0x1000873B));
+			PatchMemoryNop(JIPUtils::GetAddress(0x10008791), 6);
+			WriteRelCall(JIPUtils::GetAddress(0x10008791), CallFunctionAlt);
 
 			kRemoveTileFromUpdateList.ReplaceCallEx(0x706C98, &Hook::CleanupTile);
 		}
+#pragma optimize("", on)
 	}
 
 	namespace PowerArmorCondition {
@@ -1231,11 +1193,11 @@ namespace JIPFixes {
 		}
 
 		void InitHooks() {
-			uiReturnAddr = GetJIPAddress(0x1003BD6C);
-			SafeWrite8(GetJIPAddress(0x1003BD5A) + 1, 0x3D); // Change reg to EDI
-			SafeWrite8(GetJIPAddress(0x1003BDB1), 0x90);
-			SafeWrite8(GetJIPAddress(0x1003BD58) + 1, 0x58);
-			WriteRelJump(GetJIPAddress(0x1003BD66), GetTileIndex_Asm);
+			uiReturnAddr = JIPUtils::GetAddress(0x1003BD6C);
+			SafeWrite8(JIPUtils::GetAddress(0x1003BD5A) + 1, 0x3D); // Change reg to EDI
+			SafeWrite8(JIPUtils::GetAddress(0x1003BDB1), 0x90);
+			SafeWrite8(JIPUtils::GetAddress(0x1003BD58) + 1, 0x58);
+			WriteRelJump(JIPUtils::GetAddress(0x1003BD66), GetTileIndex_Asm);
 		}
 	}
 
@@ -1390,9 +1352,9 @@ namespace JIPFixes {
 		}
 
 		void InitHooks() {
-			SafeWrite32(GetJIPAddress(0x10004963) + 1, uint32_t(AccumulateScene));
-			ReplaceCall(GetJIPAddress(0x1002D27D), RenderWater);
-			PatchMemoryNop(GetJIPAddress(0x10004976), 2);
+			SafeWrite32(JIPUtils::GetAddress(0x10004963) + 1, uint32_t(AccumulateScene));
+			ReplaceCall(JIPUtils::GetAddress(0x1002D27D), RenderWater);
+			PatchMemoryNop(JIPUtils::GetAddress(0x10004976), 2);
 		}
 	}
 
@@ -1417,15 +1379,15 @@ namespace JIPFixes {
 		}
 
 		void InitHooks() {
-			uiReturnAddr = GetJIPAddress(0x10038FA2);
-			WriteRelJump(GetJIPAddress(0x10038F4A), GetBarterRef_Asm);
+			uiReturnAddr = JIPUtils::GetAddress(0x10038FA2);
+			WriteRelJump(JIPUtils::GetAddress(0x10038F4A), GetBarterRef_Asm);
 		}
 	}
 
 	namespace Update3DTweak {
 
 		void InitHooks() {
-			SafeWrite8(GetJIPAddress(0x1005825F) + 1, 0); // Change priority to critical
+			SafeWrite8(JIPUtils::GetAddress(0x1005825F) + 1, 0); // Change priority to critical
 		}
 	}
 
@@ -1440,8 +1402,8 @@ namespace JIPFixes {
 		}
 
 		void InitHooks() {
-			uiSetItemHealthAddr = GetJIPAddress(0x1000D520);
-			ReplaceCall(GetJIPAddress(0x10058476), SetItemHealth);
+			uiSetItemHealthAddr = JIPUtils::GetAddress(0x1000D520);
+			ReplaceCall(JIPUtils::GetAddress(0x10058476), SetItemHealth);
 		}
 	}
 
@@ -1618,17 +1580,17 @@ namespace JIPFixes {
 		}
 
 		void InitHooks() {
-			uiReturnAddr = GetJIPAddress(0x10015B43);
-			uiGiveUpAddr = GetJIPAddress(0x10015560);
+			uiReturnAddr = JIPUtils::GetAddress(0x10015B43);
+			uiGiveUpAddr = JIPUtils::GetAddress(0x10015560);
 
-			WriteRelJump(GetJIPAddress(0x10015B3D), SanityCheck_Asm);
+			WriteRelJump(JIPUtils::GetAddress(0x10015B3D), SanityCheck_Asm);
 
 			// Fix offset size
-			SafeWrite8(GetJIPAddress(0x100167EA + 2), 0xC0);
+			SafeWrite8(JIPUtils::GetAddress(0x100167EA + 2), 0xC0);
 
 			// Raise current version to 2
-			SafeWrite8(GetJIPAddress(0x10015B33 + 3), uiJIPExtraDataVersion);
-			SafeWrite8(GetJIPAddress(0x10016761 + 1), uiJIPExtraDataVersion);
+			SafeWrite8(JIPUtils::GetAddress(0x10015B33 + 3), uiJIPExtraDataVersion);
+			SafeWrite8(JIPUtils::GetAddress(0x10016761 + 1), uiJIPExtraDataVersion);
 		}
 	}
 
@@ -1698,31 +1660,35 @@ namespace JIPFixes {
 		};
 
 		void InitHooks() {
-			uiHashAddr = GetJIPAddress(0x100010F0);
-			uiAllocAddr = GetJIPAddress(0x10003C80);
+			uiHashAddr = JIPUtils::GetAddress(0x100010F0);
+			uiAllocAddr = JIPUtils::GetAddress(0x10003C80);
 
-			PatchMemoryNop(GetJIPAddress(0x10011B13), 2);
+			PatchMemoryNop(JIPUtils::GetAddress(0x10011B13), 2);
 
-			pGSMap = reinterpret_cast<SettingsMap*>(GetJIPAddress(0x1006FF84));
+			pGSMap = reinterpret_cast<SettingsMap*>(JIPUtils::GetAddress(0x1006FF84));
 			InitializeMap();
 
 			kRegisterGameSetting.ReplaceCallEx(0x404E87, &Hook::RegisterGameSetting);
 		}
 	}
 
+		}
+	}
+
 	namespace LogMover {
 
 		void InitHooks() {
-			FILE** pLog = reinterpret_cast<FILE**>(GetJIPAddress(0x1006A388));
-			if (!pLog[0] || fclose(pLog[0]) != 0)
+			FILE** pLog = reinterpret_cast<FILE**>(JIPUtils::GetAddress(0x1006A388));
+			if (!pLog[0] || fclose(pLog[0]))
 				return;
 
-			if (MoveFileExA("jip_ln_nvse.log", "logs\\jip_ln_nvse.log", MOVEFILE_REPLACE_EXISTING)) {
+			if (MoveFileEx("jip_ln_nvse.log", "logs\\jip_ln_nvse.log", MOVEFILE_REPLACE_EXISTING)) {
 				pLog[0] = _fsopen("logs\\jip_ln_nvse.log", "a+b", _SH_DENYWR);
-				void(__cdecl * PrintLog)(const char* apText, ...) = reinterpret_cast<void(__cdecl*)(const char*, ...)>(GetJIPAddress(0x10006740));
+				void(__cdecl * PrintLog)(const char* apText, ...) = reinterpret_cast<void(__cdecl*)(const char*, ...)>(JIPUtils::GetAddress(0x10006740));
 				PrintLog("JohnnyGuitar Fixes and Tweaks initialized");
 			}
 		}
+
 	}
 
 	namespace VersionPrint {
@@ -1730,91 +1696,17 @@ namespace JIPFixes {
 		const char cVersionString[] = "JIP LN version: %.2f + JohnnyGuitar Fixes and Tweaks";
 
 		void InitHooks() {
-			SafeWrite32(GetJIPAddress(0x1001359D) + 1, size_t(&cVersionString));
+			SafeWrite32(JIPUtils::GetAddress(0x1001359D) + 1, size_t(&cVersionString));
 		}
-	}
 
-	void ShowErrorMessage(const char* fmt, ...) {
-		char cBuffer[512];
-		const char* pPrefix = "JIP LN Fixes error:\n";
-		const char* pSuffix = "\n\nJIP LN Fixes will be disabled.\nTo disable this message, set bJIPFixes to 0 in JohnnyGuitar.ini or use the latest supported JIP LN 57.30";
-		strcpy_s(cBuffer, pPrefix);
-		const uint32_t uiPrefixLen = strlen(pPrefix);
-		va_list args;
-		va_start(args, fmt);
-		vsprintf_s(cBuffer + uiPrefixLen, sizeof(cBuffer) - uiPrefixLen, fmt, args);
-		va_end(args);
-		strcat_s(cBuffer, pSuffix);
-		MessageBox(NULL, cBuffer, "JohnnyGuitarNVSE", MB_OK | MB_ICONERROR);
-		hJIP = nullptr;
 	}
 
 	void InitData() {
-		HMODULE hJIPModule = GetModuleHandle("jip_nvse.dll");
-		if (!hJIPModule) {
-			_MESSAGE("Failed to find JIP LN!");
-			return;
-		}
-
-		const PluginInfo* pInfo = g_cmdTableInterface->GetPluginInfoByName("JIP LN NVSE");
-		if (!pInfo) {
-			ShowErrorMessage("Failed to get JIP LN plugin info!");
-			return;
-		}
-
-		if (pInfo->version != 5730) {
-			double dVersion = pInfo->version / 100.0;
-			ShowErrorMessage("Incompatible JIP LN version! Expected 57.30, got %.2f.", dVersion);
-			return;
-		}
-
-		HANDLE hJIPFile = CreateFile("Data\\NVSE\\Plugins\\jip_nvse.dll", GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, nullptr);
-
-		if (!hJIPFile || hJIPFile == INVALID_HANDLE_VALUE) {
-			_MESSAGE("Failed to find JIP LN!");
-			return;
-		}
-
-		DWORD dwFileSize = GetFileSize(hJIPFile, nullptr);
-
-		if (dwFileSize != JIP_TARGET_SIZE) {
-			ShowErrorMessage("Incompatible JIP LN version!");
-			return;
-		}
-
-		DWORD dwBytesRead = 0;
-		HANDLE hMemoryMapping = CreateFileMapping(hJIPFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
-		if (!hMemoryMapping) {
-			CloseHandle(hJIPFile);
-			ShowErrorMessage("Failed to create JIP LN mapping!");
-			return;
-		}
-
-		const uint8_t* pFileData = reinterpret_cast<const uint8_t*>(MapViewOfFile(hMemoryMapping, FILE_MAP_READ, 0, 0, 0));
-		if (!pFileData) {
-			CloseHandle(hMemoryMapping);
-			CloseHandle(hJIPFile);
-			ShowErrorMessage("Failed to read JIP LN!");
-			return;
-		}
-
-		const uint32_t uiHash = crc32(pFileData, dwFileSize);
-
-		UnmapViewOfFile(pFileData);
-		CloseHandle(hMemoryMapping);
-		CloseHandle(hJIPFile);
-
-		if (uiHash != JIP_TARGET_HASH) {
-			ShowErrorMessage("Incompatible JIP LN binary!");
-			return;
-		}
-
-		hJIP = hJIPModule;
-		_MESSAGE("JIP LN detected and verified.");
+		JIPUtils::Init();
 	}
 
 	void InitEarlyHooks() {
-		if (!hJIP)
+		if (!JIPUtils::IsValid())
 			return;
 
 		if (bIsGECK) {
@@ -1830,7 +1722,7 @@ namespace JIPFixes {
 	}
 
 	void InitHooks() {
-		if (!hJIP)
+		if (!JIPUtils::IsValid())
 			return;
 
 		if (bIsGECK) {
@@ -1854,11 +1746,12 @@ namespace JIPFixes {
 			Update3DTweak::InitHooks();
 			AddItemAltNoCond::InitHooks();
 			ExtraDataFixes::InitHooks();
+			EDIDLookupTweak::InitHooks();
 		}
 	}
 
 	void InitCommandHooks() {
-		if (!hJIP)
+		if (!JIPUtils::IsValid())
 			return;
 
 		SetOnDialogTopicEventHandlerEx::InitHooks();
@@ -1871,7 +1764,7 @@ namespace JIPFixes {
 	}
 
 	void InitDeferredHooks() {
-		if (!hJIP)
+		if (!JIPUtils::IsValid())
 			return;
 
 		if (bIsGECK) {

--- a/JG/internal/JIP/JIPFixes.cpp
+++ b/JG/internal/JIP/JIPFixes.cpp
@@ -1743,7 +1743,6 @@ namespace JIPFixes {
 			Update3DTweak::InitHooks();
 			AddItemAltNoCond::InitHooks();
 			ExtraDataFixes::InitHooks();
-			EDIDLookupTweak::InitHooks();
 		}
 	}
 

--- a/JG/internal/JIP/JIPSettings.cpp
+++ b/JG/internal/JIP/JIPSettings.cpp
@@ -1,0 +1,21 @@
+#include "JIPSettings.hpp"
+#include "JIPUtils.hpp"
+
+namespace JIPSettings {
+
+	bool IsSettingClear(const char* apSetting, const char* apPath) {
+		return GetPrivateProfileInt("JIP", apSetting, 1, apPath) == 0;
+	}
+
+	void InitConditionalHooks() {
+		char cFilename[MAX_PATH];
+		GetModuleFileNameA(NULL, cFilename, MAX_PATH);
+		char* pLastSlash = strrchr(cFilename, '\\') + 1;
+		uint32_t uiLength = MAX_PATH - (pLastSlash - cFilename);
+		strcpy_s(pLastSlash, uiLength, "Data\\nvse\\plugins\\JohnnyGuitar.ini");
+
+		if (IsSettingClear("bFixPositiveChemDuration", cFilename))
+			PatchMemoryNopRange(JIPUtils::GetAddress(0x100128C3), JIPUtils::GetAddress(0x100128E1));
+	}
+
+}

--- a/JG/internal/JIP/JIPSettings.hpp
+++ b/JG/internal/JIP/JIPSettings.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace JIPSettings {
+	void InitConditionalHooks();
+}

--- a/JG/internal/JIP/JIPUtils.cpp
+++ b/JG/internal/JIP/JIPUtils.cpp
@@ -1,0 +1,121 @@
+#include "JIPUtils.hpp"
+#include "PluginAPI.h"
+
+#include <array>
+
+extern NVSECommandTableInterface* g_cmdTableInterface;
+
+namespace JIPUtils {
+
+	HMODULE hJIP = 0;
+
+	constexpr uint32_t CRC32_TABLE_SIZE = 256;
+	constexpr uint32_t JIP_TARGET_HASH = 0x9DF36B6;
+	constexpr uint32_t JIP_TARGET_SIZE = 502272;
+
+	static constexpr std::array<uint32_t, CRC32_TABLE_SIZE> initCRC32Table() {
+		constexpr uint32_t polynomial = 0xEDB88320;
+		std::array<uint32_t, CRC32_TABLE_SIZE> crc32table;
+		for (uint32_t i = 0; i < CRC32_TABLE_SIZE; i++) {
+			uint32_t crc = i;
+			for (uint32_t j = 0; j < 8; j++) {
+				if (crc & 1)
+					crc = (crc >> 1) ^ polynomial;
+				else
+					crc >>= 1;
+			}
+			crc32table[i] = crc;
+		}
+		return crc32table;
+	}
+
+
+	static uint32_t crc32(const uint8_t* data, size_t length) {
+		constexpr std::array<uint32_t, CRC32_TABLE_SIZE> crc32table = initCRC32Table();
+		uint32_t crc = 0xFFFFFFFF;
+		for (size_t i = 0; i < length; i++) {
+			uint8_t byte = data[i];
+			crc = (crc >> 8) ^ crc32table[(crc ^ byte) & 0xFF];
+		}
+		return crc ^ 0xFFFFFFFF;
+	}
+
+	void ShowErrorMessage(const char* fmt, ...) {
+		char cBuffer[512];
+		const char* pPrefix = "JIP LN Fixes error:\n";
+		const char* pSuffix = "\n\nJIP LN Fixes will be disabled.\nTo disable this message, set bJIPFixes to 0 in JohnnyGuitar.ini or use the latest supported JIP LN 57.30";
+		strcpy_s(cBuffer, pPrefix);
+		const uint32_t uiPrefixLen = strlen(pPrefix);
+		va_list args;
+		va_start(args, fmt);
+		vsprintf_s(cBuffer + uiPrefixLen, sizeof(cBuffer) - uiPrefixLen, fmt, args);
+		va_end(args);
+		strcat_s(cBuffer, pSuffix);
+		MessageBox(NULL, cBuffer, "JohnnyGuitarNVSE", MB_OK | MB_ICONERROR);
+		hJIP = nullptr;
+	}
+
+	void Init() {
+		HMODULE hJIPModule = GetModuleHandle("jip_nvse.dll");
+		if (!hJIPModule) {
+			_MESSAGE("Failed to find JIP LN!");
+			return;
+		}
+
+		const PluginInfo* pInfo = g_cmdTableInterface->GetPluginInfoByName("JIP LN NVSE");
+		if (!pInfo) {
+			ShowErrorMessage("Failed to get JIP LN plugin info!");
+			return;
+		}
+
+		if (pInfo->version != 5730) {
+			double dVersion = pInfo->version / 100.0;
+			ShowErrorMessage("Incompatible JIP LN version! Expected 57.30, got %.2f.", dVersion);
+			return;
+		}
+
+		HANDLE hJIPFile = CreateFile("Data\\NVSE\\Plugins\\jip_nvse.dll", GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, nullptr);
+
+		if (!hJIPFile || hJIPFile == INVALID_HANDLE_VALUE) {
+			_MESSAGE("Failed to find JIP LN!");
+			return;
+		}
+
+		DWORD dwFileSize = GetFileSize(hJIPFile, nullptr);
+
+		if (dwFileSize != JIP_TARGET_SIZE) {
+			ShowErrorMessage("Incompatible JIP LN version!");
+			return;
+		}
+
+		DWORD dwBytesRead = 0;
+		HANDLE hMemoryMapping = CreateFileMapping(hJIPFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
+		if (!hMemoryMapping) {
+			CloseHandle(hJIPFile);
+			ShowErrorMessage("Failed to create JIP LN mapping!");
+			return;
+		}
+
+		const uint8_t* pFileData = reinterpret_cast<const uint8_t*>(MapViewOfFile(hMemoryMapping, FILE_MAP_READ, 0, 0, 0));
+		if (!pFileData) {
+			CloseHandle(hMemoryMapping);
+			CloseHandle(hJIPFile);
+			ShowErrorMessage("Failed to read JIP LN!");
+			return;
+		}
+
+		const uint32_t uiHash = crc32(pFileData, dwFileSize);
+
+		UnmapViewOfFile(pFileData);
+		CloseHandle(hMemoryMapping);
+		CloseHandle(hJIPFile);
+
+		if (uiHash != JIP_TARGET_HASH) {
+			ShowErrorMessage("Incompatible JIP LN binary!");
+			return;
+		}
+
+		hJIP = hJIPModule;
+		_MESSAGE("JIP LN detected and verified.");
+	}
+}

--- a/JG/internal/JIP/JIPUtils.hpp
+++ b/JG/internal/JIP/JIPUtils.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace JIPUtils {
+
+	extern HMODULE hJIP;
+
+	static inline BOOL IsValid() {
+		return hJIP != 0;
+	}
+
+	static inline size_t __fastcall GetAddress(size_t aiAddress) {
+		return reinterpret_cast<size_t>(hJIP) + aiAddress - 0x10000000;
+	}
+
+	void Init();
+}

--- a/JG/nvse_plugin_example.vcxproj
+++ b/JG/nvse_plugin_example.vcxproj
@@ -187,6 +187,7 @@ copy "$(TargetDir)$(TargetName).pdb" "C:\Symbols\$(TargetName).pdb"
     <ClCompile Include="internal\Game\Bethesda\TESLeveledList.cpp" />
     <ClCompile Include="internal\Game\Bethesda\TESObject.cpp" />
     <ClCompile Include="internal\Game\Bethesda\TESObjectList.cpp" />
+    <ClCompile Include="internal\Game\Bethesda\TLSData.cpp" />
     <ClCompile Include="internal\Game\Gamebryo\NiFixedString.cpp" />
     <ClCompile Include="internal\Game\Gamebryo\NiGlobalStringTable.cpp" />
     <ClCompile Include="internal\Game\Gamebryo\NiMemObject.cpp" />
@@ -211,6 +212,7 @@ copy "$(TargetDir)$(TargetName).pdb" "C:\Symbols\$(TargetName).pdb"
     <ClCompile Include="internal\JG\ExtraMiscStats.cpp" />
     <ClCompile Include="internal\JG\ExtraReputationIcons.cpp" />
     <ClCompile Include="internal\JG\ExtraUISounds.cpp" />
+    <ClCompile Include="internal\JG\FixedStringsRework.cpp" />
     <ClCompile Include="internal\JG\JohnnyFixes.cpp" />
     <ClCompile Include="internal\JG\JohnnyPatches.cpp" />
     <ClCompile Include="internal\JG\JohnnyGameSettings.cpp" />
@@ -223,6 +225,8 @@ copy "$(TargetDir)$(TargetName).pdb" "C:\Symbols\$(TargetName).pdb"
     <ClCompile Include="internal\JG\RSMBarberHook.cpp" />
     <ClCompile Include="internal\JG\TaskQueue.cpp" />
     <ClCompile Include="internal\JIP\JIPFixes.cpp" />
+    <ClCompile Include="internal\JIP\JIPSettings.cpp" />
+    <ClCompile Include="internal\JIP\JIPUtils.cpp" />
     <ClCompile Include="internal\md5\md5.cpp" />
     <ClCompile Include="internal\netimmerse.cpp" />
     <ClCompile Include="internal\serialization.cpp" />
@@ -356,6 +360,7 @@ copy "$(TargetDir)$(TargetName).pdb" "C:\Symbols\$(TargetName).pdb"
     <ClInclude Include="internal\Game\Bethesda\TESObject.hpp" />
     <ClInclude Include="internal\Game\Bethesda\TESObjectList.hpp" />
     <ClInclude Include="internal\Game\Bethesda\TESTextureList.hpp" />
+    <ClInclude Include="internal\Game\Bethesda\TLSData.hpp" />
     <ClInclude Include="internal\Game\Gamebryo\NiCriticalSection.hpp" />
     <ClInclude Include="internal\Game\Gamebryo\NiFixedString.hpp" />
     <ClInclude Include="internal\Game\Gamebryo\NiGlobalStringTable.hpp" />
@@ -422,6 +427,7 @@ copy "$(TargetDir)$(TargetName).pdb" "C:\Symbols\$(TargetName).pdb"
     <ClInclude Include="internal\JG\ExtraMiscStats.hpp" />
     <ClInclude Include="internal\JG\ExtraReputationIcons.hpp" />
     <ClInclude Include="internal\JG\ExtraUISounds.hpp" />
+    <ClInclude Include="internal\JG\FixedStringsRework.hpp" />
     <ClInclude Include="internal\JG\JGSetList.hpp" />
     <ClInclude Include="internal\JG\JohnnyFixes.hpp" />
     <ClInclude Include="internal\JG\JohnnyPatches.hpp" />
@@ -435,6 +441,8 @@ copy "$(TargetDir)$(TargetName).pdb" "C:\Symbols\$(TargetName).pdb"
     <ClInclude Include="internal\JG\RSMBarberHook.hpp" />
     <ClInclude Include="internal\JG\TaskQueue.hpp" />
     <ClInclude Include="internal\JIP\JIPFixes.hpp" />
+    <ClInclude Include="internal\JIP\JIPSettings.hpp" />
+    <ClInclude Include="internal\JIP\JIPUtils.hpp" />
     <ClInclude Include="internal\md5\md5.h" />
     <ClInclude Include="internal\netimmerse.h" />
     <ClInclude Include="internal\serialization.h" />

--- a/JG/nvse_plugin_example.vcxproj.filters
+++ b/JG/nvse_plugin_example.vcxproj.filters
@@ -373,6 +373,18 @@
     <ClCompile Include="internal\JG\RadioSkipOGGWAVPatch.cpp">
       <Filter>internal\JG</Filter>
     </ClCompile>
+    <ClCompile Include="internal\JIP\JIPSettings.cpp">
+      <Filter>internal\JIP</Filter>
+    </ClCompile>
+    <ClCompile Include="internal\JIP\JIPUtils.cpp">
+      <Filter>internal\JIP</Filter>
+    </ClCompile>
+    <ClCompile Include="internal\JG\FixedStringsRework.cpp">
+      <Filter>internal\JG</Filter>
+    </ClCompile>
+    <ClCompile Include="internal\Game\Bethesda\TLSData.cpp">
+      <Filter>internal\Game\Bethesda</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\nvse\nvse\GameAPI.h">
@@ -1005,6 +1017,18 @@
     </ClInclude>
     <ClInclude Include="internal\JG\RadioSkipOGGWAVPatch.hpp">
       <Filter>internal\JG</Filter>
+    </ClInclude>
+    <ClInclude Include="internal\JIP\JIPSettings.hpp">
+      <Filter>internal\JIP</Filter>
+    </ClInclude>
+    <ClInclude Include="internal\JIP\JIPUtils.hpp">
+      <Filter>internal\JIP</Filter>
+    </ClInclude>
+    <ClInclude Include="internal\JG\FixedStringsRework.hpp">
+      <Filter>internal\JG</Filter>
+    </ClInclude>
+    <ClInclude Include="internal\Game\Bethesda\TLSData.hpp">
+      <Filter>internal\Game\Bethesda</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/nvse/nvse/GameAPI.cpp
+++ b/nvse/nvse/GameAPI.cpp
@@ -6,6 +6,7 @@
 #include "CommandTable.h"
 #include "GameScript.h"
 #include "StringVar.h"
+#include <Bethesda/TLSData.hpp>
 
 static NVSEStringVarInterface* s_StringVarInterface = NULL;
 bool extraTraces = false;
@@ -58,38 +59,8 @@ const _ShowCompilerError ShowCompilerError = (_ShowCompilerError)0x005C5730;	// 
 
 #if RUNTIME
 
-struct TLSData {
-	// thread local storage
-
-	uint32_t	pad000[(0x260 - 0x000) >> 2];	// 000
-	NiNode* lastNiNode;			// 260
-	TESObjectREFR* lastNiNodeREFR;		// 264
-	uint8_t			consoleMode;			// 268
-	uint8_t			pad269[3];				// 269
-	// 25C is used as do not head track the player , 2B8 is used to init QueudFile::unk0018
-};
-
-static TLSData* GetTLSData() {
-	uint32_t TlsIndex = *g_TlsIndexPtr;
-	TLSData* data = NULL;
-
-	__asm {
-		mov		ecx, [TlsIndex]
-		mov		edx, fs: [2Ch]	// linear address of thread local storage array
-		mov		eax, [edx + ecx * 4]
-		mov[data], eax
-	}
-
-	return data;
-}
-
 bool IsConsoleMode() {
-	TLSData* tlsData = GetTLSData();
-
-	if (tlsData)
-		return tlsData->consoleMode != 0;
-
-	return false;
+	return TLSData::Get()->bConsoleOutput;
 }
 
 bool GetConsoleEcho() {


### PR DESCRIPTION
Why? Because JIP's version struggles with the number of strings added by our EDID implementation. Also uses linked lists for buckets, which is eehhhhh. Point is, it's faster now.

Also modularizes JIP patches, due to dependencies.