### PR TITLE
Add GetItemEffectString function

### DIFF
--- a/JG/JohnnyGuitarNVSE.cpp
+++ b/JG/JohnnyGuitarNVSE.cpp
@@ -545,6 +545,7 @@ void RegisterCommands(const NVSEInterface* nvse) {
 	REG_CMD(RemapLand);
 	REG_CMD(SetParticleEmitterSpawnRate);
 	REG_CMD(GetParticleEmitterSpawnRate);
+	REG_TYPED_CMD(GetItemEffectString, String);
 }
 
 EXTERN_DLL_EXPORT bool NVSEPlugin_Query(const NVSEInterface* nvse, PluginInfo* info) {

--- a/JG/functions/fn_form.cpp
+++ b/JG/functions/fn_form.cpp
@@ -2691,7 +2691,7 @@ bool Cmd_RemapLand_Execute(COMMAND_ARGS) {
 bool Cmd_GetItemEffectString_Execute(COMMAND_ARGS) {
 	*result = 0;
 	TESForm* form = NULL;
-	char extraEffects[0x100] = {};
+	char effects[0x100] = {};
 
 	ExtractArgsEx(EXTRACT_ARGS_EX, &form);
 	if (!form) {
@@ -2700,7 +2700,7 @@ bool Cmd_GetItemEffectString_Execute(COMMAND_ARGS) {
 	}
 
 	switch (form->GetFormType()) {
-		
+
 		// Item mod
 		case FORM_TYPE::TESObjectIMOD:
 		{
@@ -2708,46 +2708,46 @@ bool Cmd_GetItemEffectString_Execute(COMMAND_ARGS) {
 			if (itemMod) {
 				const char* modDesc = itemMod->description.Get(itemMod, 'CSED');
 				if (modDesc) {
-					strcpy_s(extraEffects, sizeof(extraEffects), modDesc);
+					strcpy_s(effects, sizeof(effects), modDesc);
 				}
 			}
 		}
 		break;
-		
+
 		// Ingestible
 		case FORM_TYPE::AlchemyItem:
 		{
 			AlchemyItem* ingestible = static_cast<AlchemyItem*>(form);
 			if (ingestible) {
-				ThisCall(0x406620, &(ingestible->magicItem.list), extraEffects, sizeof(extraEffects));
+				ThisCall(0x406620, &(ingestible->magicItem.list), effects, sizeof(effects));
 			}
 		}
 		break;
-		
+
 		// Ammo
 		case FORM_TYPE::TESAmmo:
 		{
 			TESAmmo* ammo = static_cast<TESAmmo*>(form);
 			if (ammo) {
-				ThisCall(0x503A70, ammo, extraEffects, sizeof(extraEffects));
+				ThisCall(0x503A70, ammo, effects, sizeof(effects));
 			}
 		}
 		break;
-		
+
 		// Weapon & Armor
 		default:
 		{
 			TESEnchantableForm* enchantable = DYNAMIC_CAST(form, TESForm, TESEnchantableForm);
 			if (enchantable && enchantable->enchantItem) {
-				ThisCall(0x406620, &(enchantable->enchantItem->magicItem.list), extraEffects, sizeof(extraEffects));
+				ThisCall(0x406620, &(enchantable->enchantItem->magicItem.list), effects, sizeof(effects));
 			}
 		}
 	}
 
-	g_strInterface->Assign(PASS_COMMAND_ARGS, extraEffects);
+	g_strInterface->Assign(PASS_COMMAND_ARGS, effects);
 
 	if (IsConsoleMode())
-		Console_Print("GetItemEffectString >> %s", extraEffects);
+		Console_Print("GetItemEffectString >> %s", effects);
 
 	return true;
 }

--- a/JG/functions/fn_form.cpp
+++ b/JG/functions/fn_form.cpp
@@ -2690,64 +2690,61 @@ bool Cmd_RemapLand_Execute(COMMAND_ARGS) {
 
 bool Cmd_GetItemEffectString_Execute(COMMAND_ARGS) {
 	*result = 0;
-	TESForm* form = NULL;
-	char effects[0x100] = {};
+	TESForm* pForm = nullptr;
 
-	ExtractArgsEx(EXTRACT_ARGS_EX, &form);
-	if (!form) {
-		if (!thisObj) return true;
-		form = thisObj->baseForm;
+	ExtractArgsEx(EXTRACT_ARGS_EX, &pForm);
+
+	if (!pForm) {
+		if (!thisObj) 
+			return true;
+		pForm = thisObj->baseForm;
 	}
 
-	switch (form->GetFormType()) {
+	if (!pForm)
+		return true;
 
+	char cEffects[512] = {};
+
+	switch (pForm->GetFormType()) {
 		// Item mod
 		case FORM_TYPE::TESObjectIMOD:
 		{
-			TESObjectIMOD* itemMod = static_cast<TESObjectIMOD*>(form);
-			if (itemMod) {
-				const char* modDesc = itemMod->description.Get(itemMod, 'CSED');
-				if (modDesc) {
-					strcpy_s(effects, sizeof(effects), modDesc);
-				}
-			}
+			const TESObjectIMOD* pItemMod = static_cast<TESObjectIMOD*>(pForm);
+			const char* pModDescription = pItemMod->description.Get(pForm, 'CSED');
+			if (pModDescription)
+				strcpy_s(cEffects, sizeof(cEffects), pModDescription);
 		}
 		break;
 
 		// Ingestible
 		case FORM_TYPE::AlchemyItem:
 		{
-			AlchemyItem* ingestible = static_cast<AlchemyItem*>(form);
-			if (ingestible) {
-				ThisCall(0x406620, &(ingestible->magicItem.list), effects, sizeof(effects));
-			}
+			const AlchemyItem* pAlchItem = static_cast<AlchemyItem*>(pForm);
+			pAlchItem->magicItem.list.GetEffectsString(cEffects, sizeof(cEffects));
 		}
 		break;
 
 		// Ammo
 		case FORM_TYPE::TESAmmo:
 		{
-			TESAmmo* ammo = static_cast<TESAmmo*>(form);
-			if (ammo) {
-				ThisCall(0x503A70, ammo, effects, sizeof(effects));
-			}
+			const TESAmmo* pAmmo = static_cast<TESAmmo*>(pForm);
+			pAmmo->GetEffectNames(cEffects, sizeof(cEffects));
 		}
 		break;
 
 		// Weapon & Armor
 		default:
 		{
-			TESEnchantableForm* enchantable = DYNAMIC_CAST(form, TESForm, TESEnchantableForm);
-			if (enchantable && enchantable->enchantItem) {
-				ThisCall(0x406620, &(enchantable->enchantItem->magicItem.list), effects, sizeof(effects));
-			}
+			const EnchantmentItem* pItem = TESEnchantableForm::GetFormEnchanting(pForm);
+			if (pItem)
+				pItem->magicItem.list.GetEffectsString(cEffects, sizeof(cEffects));
 		}
 	}
 
-	g_strInterface->Assign(PASS_COMMAND_ARGS, effects);
+	g_strInterface->Assign(PASS_COMMAND_ARGS, cEffects);
 
 	if (IsConsoleMode())
-		Console_Print("GetItemEffectString >> %s", effects);
+		Console_Print("GetItemEffectString >> %s", cEffects);
 
 	return true;
 }

--- a/JG/functions/fn_form.cpp
+++ b/JG/functions/fn_form.cpp
@@ -458,7 +458,7 @@ bool Cmd_GetWorldspaceEncounterZone_Execute(COMMAND_ARGS) {
 	TESWorldSpace* world = nullptr;
 	if (ExtractArgsEx(EXTRACT_ARGS_EX, &world) && world && IS_TYPE(world, TESWorldSpace)) {
 		BGSEncounterZone* zone = world->pEncounterZone;
-		if (zone) 
+		if (zone)
 			*(uint32_t*)result = zone->GetFormID();
 	}
 	return true;
@@ -2682,8 +2682,72 @@ bool Cmd_RemapLand_Execute(COMMAND_ARGS) {
 				TaskQueue::QueueTask(kTask);
 			}
 		}
-		
+
 		*result = 1;
 	}
+	return true;
+}
+
+bool Cmd_GetItemEffectString_Execute(COMMAND_ARGS) {
+	*result = 0;
+	TESForm* form = NULL;
+	char extraEffects[0x100] = {};
+
+	ExtractArgsEx(EXTRACT_ARGS_EX, &form);
+	if (!form) {
+		if (!thisObj) return true;
+		form = thisObj->baseForm;
+	}
+
+	switch (form->GetFormType()) {
+		
+		// Item mod
+		case FORM_TYPE::TESObjectIMOD:
+		{
+			TESObjectIMOD* itemMod = static_cast<TESObjectIMOD*>(form);
+			if (itemMod) {
+				const char* modDesc = itemMod->description.Get(itemMod, 'CSED');
+				if (modDesc) {
+					strcpy_s(extraEffects, sizeof(extraEffects), modDesc);
+				}
+			}
+		}
+		break;
+		
+		// Ingestible
+		case FORM_TYPE::AlchemyItem:
+		{
+			AlchemyItem* ingestible = static_cast<AlchemyItem*>(form);
+			if (ingestible) {
+				ThisCall(0x406620, &(ingestible->magicItem.list), extraEffects, sizeof(extraEffects));
+			}
+		}
+		break;
+		
+		// Ammo
+		case FORM_TYPE::TESAmmo:
+		{
+			TESAmmo* ammo = static_cast<TESAmmo*>(form);
+			if (ammo) {
+				ThisCall(0x503A70, ammo, extraEffects, sizeof(extraEffects));
+			}
+		}
+		break;
+		
+		// Weapon & Armor
+		default:
+		{
+			TESEnchantableForm* enchantable = DYNAMIC_CAST(form, TESForm, TESEnchantableForm);
+			if (enchantable && enchantable->enchantItem) {
+				ThisCall(0x406620, &(enchantable->enchantItem->magicItem.list), extraEffects, sizeof(extraEffects));
+			}
+		}
+	}
+
+	g_strInterface->Assign(PASS_COMMAND_ARGS, extraEffects);
+
+	if (IsConsoleMode())
+		Console_Print("GetItemEffectString >> %s", extraEffects);
+
 	return true;
 }

--- a/JG/functions/fn_form.h
+++ b/JG/functions/fn_form.h
@@ -118,3 +118,4 @@ DEFINE_COMMAND_PLUGIN_EXP(CallPerMobileObjectEx, , false, kParamsCallPerMobileOb
 DEFINE_COMMAND_PLUGIN(Update3DAlt, , true, kParams_OneInt);
 DEFINE_COMMAND_PLUGIN(GetRecipeCategoryFlags, , false, kParams_OneForm);
 DEFINE_COMMAND_PLUGIN(RemapLand, , false, kParamsRemapLand);
+DEFINE_COMMAND_PLUGIN(GetItemEffectString, , false, kParams_OneOptionalObjectID);

--- a/nvse/nvse/GameForms.h
+++ b/nvse/nvse/GameForms.h
@@ -393,6 +393,10 @@ public:
 	uint16_t	unk1;					// 0A
 	uint32_t	unk2;					// 0C
 	// 010
+
+	static EnchantmentItem* GetFormEnchanting(TESForm* apForm) {
+		return CdeclCall<EnchantmentItem*>(0x4BE330, apForm);
+	}
 };
 
 class TESImageSpaceModifier;
@@ -527,6 +531,10 @@ public:
 	uint32_t uiHostileCount;
 
 	bool RemoveNthEffect(uint32_t index);
+
+	void GetEffectsString(char* apBuffer, uint32_t auiBufferSize) const {
+		ThisCall(0x406620, this, apBuffer, auiBufferSize);
+	}
 };
 
 static_assert(sizeof(EffectItemList) == 0x10);
@@ -1193,7 +1201,7 @@ public:
 	TESDescription();
 	~TESDescription();
 
-	virtual const char* Get(TESForm* overrideForm, uint32_t chunkID);
+	virtual const char* Get(TESForm* overrideForm, uint32_t chunkID) const;
 
 	uint32_t	formDiskOffset;	// 4 - how does this work for descriptions in mods?
 	// maybe extracts the mod ID then uses that to find the src file?
@@ -2851,6 +2859,10 @@ public:
 	bool IsNonPlayable() { return (flags & kFlags_NonPlayable) == kFlags_NonPlayable; }
 	bool IsPlayable() { return !IsNonPlayable(); }
 	void SetPlayable(bool doset) { if (doset) flags &= ~kFlags_NonPlayable; else flags |= kFlags_NonPlayable; }
+
+	void GetEffectNames(char* apBuffer, uint32_t auiBufferSize) const {
+		ThisCall(0x503A70, this, apBuffer, auiBufferSize);
+	}
 };
 
 static_assert(sizeof(TESAmmo) == 0xDC);


### PR DESCRIPTION
Returns the effect string for an item as it would appear in the item card.

Might need to increase the buffer size, not sure what the max effect string length could be.

Also need to consider support for Stewie's "bShowWeaponPoisonEffects" and "bShowBookEffects" tweaks.