### PR TITLE
Add 7 functions for kick mod

### DIFF
--- a/JG/functions/fn_hit.cpp
+++ b/JG/functions/fn_hit.cpp
@@ -1,0 +1,994 @@
+#include "fn_hit.h"
+
+#include "Bethesda/BSEnums.hpp"
+#include "Bethesda/BSUtilities.hpp"
+#include "Bethesda/TESDataHandler.hpp"
+#include "Gamebryo/NiFixedString.hpp"
+
+#include <GameForms.h>
+#include <GameObjects.h>
+#include <GameProcess.h>
+#include <GameSound.h>
+#include <netimmerse.h>
+#include <decoding.h>
+
+#include <JG/PlayerBodyOverlay.hpp>
+
+#include <cstddef>
+#include <cmath>
+#include <cstring>
+#include <limits>
+
+namespace {
+
+using ImpactSwap = TESWorldSpace::ImpactSwap;
+
+static_assert(BHK_MATERIAL_MASK_FIXED == 0x3F);
+
+constexpr uintptr_t kAddrCreateTempEffectParticle = 0x6890B0;
+constexpr uintptr_t kAddrDecalManagerSingleton = 0x11C57F8;
+constexpr uintptr_t kAddrAddDecal = 0x4A10D0;
+constexpr uintptr_t kAddrMergeScriptEvent = 0x5AC750;
+constexpr uintptr_t kAddrSendAssaultAlarm = 0x8C0460;
+constexpr uintptr_t kAddrGetMaterialFromCollidable = 0x62B150;
+constexpr uintptr_t kAddrGetSubshapeMaterial = 0xC84F10;
+constexpr uintptr_t kAddrGetCollisionFilter = 0x931ED0;
+constexpr uintptr_t kAddrPick = 0x458440;
+constexpr uintptr_t kAddrCalcPickHitPoint = 0x5DBE60;
+constexpr uintptr_t kAddrVisitHavokObjects = 0xC68900;
+constexpr uintptr_t kAddrClearAnimGroup = 0x496080;
+constexpr uintptr_t kAddrSetAnimActionAndSequence = 0x8A73E0;
+constexpr uintptr_t kAddrSetRigidBodyLinearVelocity = 0x561690;
+constexpr uint32_t kActorDamageVtableSlot = 0xCE;
+constexpr uint32_t kShapeGetContainerVtableSlot = 4;
+constexpr uint32_t kShapeGetChildVtableSlot = 5;
+constexpr uint32_t kRigidBodyCenterVtableSlot = 0xF0 / 4;
+
+static_assert(sizeof(ActorHitData) == 0x64);
+static_assert(offsetof(ActorHitData, source) == 0x00);
+static_assert(offsetof(ActorHitData, target) == 0x04);
+static_assert(offsetof(ActorHitData, unk0C) == 0x0C);
+static_assert(offsetof(ActorHitData, hitLocation) == 0x10);
+static_assert(offsetof(ActorHitData, healthDmg) == 0x14);
+static_assert(offsetof(ActorHitData, wpnBaseDmg) == 0x18);
+static_assert(offsetof(ActorHitData, fatigueDmg) == 0x1C);
+static_assert(offsetof(ActorHitData, limbDmg) == 0x20);
+static_assert(offsetof(ActorHitData, weapon) == 0x30);
+static_assert(offsetof(ActorHitData, healthPerc) == 0x34);
+static_assert(offsetof(ActorHitData, impactPos) == 0x38);
+static_assert(offsetof(ActorHitData, impactAngle) == 0x44);
+static_assert(offsetof(ActorHitData, flags) == 0x58);
+static_assert(offsetof(ActorHitData, dmgMult) == 0x5C);
+static_assert(sizeof(TESObjectWEAP) == 0x388);
+static_assert(offsetof(TESObjectWEAP, weaponSkill) == 0x15C);
+static_assert(offsetof(TESObjectWEAP, impactDataSet) == 0x24C);
+static_assert(sizeof(BGSImpactData) == 0x78);
+static_assert(offsetof(BGSImpactData, model) == 0x18);
+static_assert(offsetof(BGSImpactData, effectDuration) == 0x30);
+static_assert(offsetof(BGSImpactData, angleThreshold) == 0x38);
+static_assert(offsetof(BGSImpactData, placementRadius) == 0x3C);
+static_assert(offsetof(BGSImpactData, textureSet) == 0x48);
+static_assert(offsetof(BGSImpactData, sound1) == 0x4C);
+static_assert(offsetof(BGSImpactData, sound2) == 0x50);
+static_assert(offsetof(BGSImpactData, decalMaxWidth) == 0x58);
+static_assert(offsetof(BGSImpactData, decalMaxHeight) == 0x60);
+static_assert(offsetof(BGSImpactData, decalDepth) == 0x64);
+static_assert(offsetof(BGSImpactData, decalShininess) == 0x68);
+static_assert(offsetof(BGSImpactData, parallaxScale) == 0x6C);
+static_assert(offsetof(BGSImpactData, parallaxPasses) == 0x70);
+static_assert(offsetof(BGSImpactData, decalFlags) == 0x71);
+static_assert(offsetof(BGSImpactData, decalColor) == 0x74);
+static_assert(sizeof(BGSImpactDataSet) == 0x4C);
+static_assert(offsetof(BGSImpactDataSet, impactDatas) == 0x1C);
+static_assert(sizeof(TESSound) == 0x68);
+static_assert(offsetof(TESForm, uiFormID) == 0x0C);
+static_assert(sizeof(BSSoundHandle) == 0x0C);
+static_assert(offsetof(BSSoundHandle, uiSoundID) == 0x00);
+static_assert(offsetof(TESNPC, impactMaterialType) == 0x1E4);
+static_assert(offsetof(TESCreature, materialType) == 0x148);
+static_assert(sizeof(Animation) == 0x12C);
+static_assert(offsetof(Animation, unk0D8) == 0xD8);
+static_assert(offsetof(Animation, animSequence) == 0xE0);
+static_assert(offsetof(BaseProcess, processLevel) == 0x28);
+static_assert(offsetof(HighProcess, animData) == 0x1C0);
+static_assert(offsetof(HighProcess, currentAction) == 0x2EC);
+static_assert(offsetof(TESObjectREFR, baseForm) == 0x20);
+static_assert(offsetof(TESObjectREFR, pos) == 0x30);
+static_assert(offsetof(TESObjectREFR, parentCell) == 0x40);
+static_assert(offsetof(TESObjectREFR, extraDataList) == 0x44);
+static_assert(offsetof(TESObjectREFR, renderState) == 0x64);
+static_assert(offsetof(TESObjectREFR::RenderState, rootNode) == 0x14);
+static_assert(offsetof(MobileObject, baseProcess) == 0x68);
+static_assert(sizeof(NiAVObject) == 0x9C);
+static_assert(offsetof(NiAVObject, m_spCollisionObject) == 0x1C);
+static_assert(offsetof(NiAVObject, m_kWorld) == 0x68);
+
+static bool IsFinite3(float afX, float afY, float afZ) {
+	return std::isfinite(afX) && std::isfinite(afY) && std::isfinite(afZ);
+}
+
+static uint32_t BodyPartConditionAV(int32_t aiLocation) {
+	switch (aiLocation) {
+		case 1: case 2:				return kAVCode_PerceptionCondition;
+		case 3: case 4:				return kAVCode_LeftAttackCondition;
+		case 5: case 6:				return kAVCode_RightAttackCondition;
+		case 7: case 8: case 9:		return kAVCode_LeftMobilityCondition;
+		case 10: case 11: case 12:	return kAVCode_RightMobilityCondition;
+		case 13:					return kAVCode_BrainCondition;
+		default:					return kAVCode_EnduranceCondition;
+	}
+}
+
+static const char* BodyPartNodeName(int32_t aiLocation) {
+	switch (aiLocation) {
+		case 1: case 2: case 13:	return "Bip01 Head";
+		case 3:						return "Bip01 L UpperArm";
+		case 4:						return "Bip01 L Forearm";
+		case 5:						return "Bip01 R UpperArm";
+		case 6:						return "Bip01 R Forearm";
+		case 7:						return "Bip01 L Thigh";
+		case 8:						return "Bip01 L Calf";
+		case 9:						return "Bip01 L Foot";
+		case 10:					return "Bip01 R Thigh";
+		case 11:					return "Bip01 R Calf";
+		case 12:					return "Bip01 R Foot";
+		default:					return "Bip01 Spine2";
+	}
+}
+
+static float BodyPartZOffset(int32_t aiLocation) {
+	switch (aiLocation) {
+		case 1: case 2: case 13:	return 120.0f;
+		case 3: case 5:				return 100.0f;
+		case 4: case 6:				return 85.0f;
+		case 7: case 10:			return 50.0f;
+		case 8: case 11:			return 25.0f;
+		case 9: case 12:			return 5.0f;
+		default:					return 80.0f;
+	}
+}
+
+static NiPoint3 FallbackHitPos(Actor* apActor, int32_t aiLocation) {
+	const NiPoint3& kPos = apActor->pos;
+	return NiPoint3(kPos.x, kPos.y, kPos.z + BodyPartZOffset(aiLocation));
+}
+
+static NiPoint3 GetActorHitWorldPos(Actor* apActor, int32_t aiLocation, NiNode*& arRootOut) {
+	// Get3DSimple, not Get3D. The player override returns the 1st person arms in 1st person.
+	arRootOut = apActor->Get3DSimple();
+	if (arRootOut) {
+		if (NiAVObject* pBone = BSUtilities::GetObjectByName(arRootOut, BodyPartNodeName(aiLocation)))
+			return pBone->m_kWorld.m_kTranslate;
+	}
+	return FallbackHitPos(apActor, aiLocation);
+}
+
+static NiPoint3 HitFXDirection(Actor* apAttacker, const NiPoint3& arPos) {
+	if (!apAttacker)
+		return NiPoint3(0.0f, 1.0f, 0.0f);
+	NiPoint3 kDir = apAttacker->pos - arPos;
+	if (!IsFinite3(kDir.x, kDir.y, kDir.z))
+		return NiPoint3(0.0f, 1.0f, 0.0f);
+	const double fLenSq =
+		static_cast<double>(kDir.x) * kDir.x +
+		static_cast<double>(kDir.y) * kDir.y +
+		static_cast<double>(kDir.z) * kDir.z;
+	if (!std::isfinite(fLenSq) || fLenSq <= 0.00000001)
+		return NiPoint3(0.0f, 1.0f, 0.0f);
+	const float fInvLen = static_cast<float>(1.0 / std::sqrt(fLenSq));
+	kDir.x *= fInvLen;
+	kDir.y *= fInvLen;
+	kDir.z *= fInvLen;
+	return kDir;
+}
+
+// Keep the 0x3F mask. The engine helper drops materials 32 through 35.
+static int32_t ConvertHavokMaterial(uint32_t auiRaw) {
+	switch (static_cast<HavokMaterialType>(auiRaw & BHK_MATERIAL_MASK_FIXED)) {
+		case BHK_MATERIAL_STONE:
+		case BHK_MATERIAL_HEAVYSTONE:
+		case BHK_MATERIAL_BROKENCONCRETE:		return ImpactSwap::eMT_Stone;
+		case BHK_MATERIAL_DIRT:
+		case BHK_MATERIAL_SAND:					return ImpactSwap::eMT_Dirt;
+		case BHK_MATERIAL_GRASS:				return ImpactSwap::eMT_Grass;
+		case BHK_MATERIAL_GLASS:
+		case BHK_MATERIAL_BOTTLE:				return ImpactSwap::eMT_Glass;
+		case BHK_MATERIAL_METAL:
+		case BHK_MATERIAL_HEAVYMETAL:
+		case BHK_MATERIAL_CHAIN:
+		case BHK_MATERIAL_SNOW:
+		case BHK_MATERIAL_ELEVATOR:
+		case BHK_MATERIAL_VEHICLEBODY:
+		case BHK_MATERIAL_VEHICLEPARTSOLID:
+		case BHK_MATERIAL_PISTOL:
+		case BHK_MATERIAL_RIFLE:
+		case BHK_MATERIAL_CHAINLINK:			return ImpactSwap::eMT_Metal;
+		case BHK_MATERIAL_WOOD:
+		case BHK_MATERIAL_HEAVYWOOD:
+		case BHK_MATERIAL_BABYRATTLE:
+		case BHK_MATERIAL_RUBBERBALL:			return ImpactSwap::eMT_Wood;
+		case BHK_MATERIAL_ORGANIC:
+		case BHK_MATERIAL_SKIN:					return ImpactSwap::eMT_Organic;
+		case BHK_MATERIAL_CLOTH:
+		case BHK_MATERIAL_CARPET:				return ImpactSwap::eMT_Cloth;
+		case BHK_MATERIAL_WATER:				return ImpactSwap::eMT_Water;
+		case BHK_MATERIAL_HOLLOWMETAL:
+		case BHK_MATERIAL_SHEETMETAL:
+		case BHK_MATERIAL_VEHICLEPARTHOLLOW:
+		case BHK_MATERIAL_BARREL:
+		case BHK_MATERIAL_SODACAN:
+		case BHK_MATERIAL_SHOPPINGCART:
+		case BHK_MATERIAL_LUNCHBOX:				return ImpactSwap::eMT_HollowMetal;
+		case BHK_MATERIAL_TILE:					return ImpactSwap::eMT_Stone;
+		case BHK_MATERIAL_TUMBLEWEED:			return ImpactSwap::eMT_Dirt;
+		default:								return -1;
+	}
+}
+
+static int32_t GetActorBodyMaterial(TESObjectREFR* apRef) {
+	TESBoundObject* pBase = apRef->baseForm;
+	if (!pBase)
+		return -1;
+	int32_t iMat = -1;
+	if (pBase->eFormType == FORM_TYPE::TESNPC)
+		iMat = static_cast<int32_t>(static_cast<TESNPC*>(pBase)->impactMaterialType);
+	else if (pBase->eFormType == FORM_TYPE::TESCreature)
+		iMat = static_cast<int32_t>(static_cast<TESCreature*>(pBase)->materialType);
+	return (iMat >= 0 && iMat < ImpactSwap::eMT_Max) ? iMat : -1;
+}
+
+static void PlayImpactSound(TESSound* apSound, const NiPoint3& arPos, NiAVObject* apNode) {
+	if (!apSound || !apSound->uiFormID)
+		return;
+	BSWin32Audio* pAudio = BSWin32Audio::GetSingleton();
+	if (!pAudio)
+		return;
+	BSSoundHandle kHandle = pAudio->GetSoundHandleByFormID(
+		apSound->uiFormID, BSAudioManager::kAudioFlags_3D | BSAudioManager::kAudioFlags_100);
+	if (kHandle.uiSoundID == 0xFFFFFFFF)
+		return;
+	kHandle.SetPosition(arPos);
+	if (apNode)
+		kHandle.SetObjectToFollow(apNode);
+	kHandle.Play(false);
+}
+
+static void PlayImpactParticle(TESObjectCELL* apCell, BGSImpactData* apImpact, const NiPoint3& arPos, const NiPoint3& arDir) {
+	if (!apCell)
+		return;
+	const char* pModelPath = apImpact->model.GetModel();
+	if (!pModelPath || !pModelPath[0])
+		return;
+	CdeclCall(kAddrCreateTempEffectParticle, apCell, apImpact->effectDuration,
+		pModelPath, arDir, arPos, 1.0f, 7, nullptr);
+}
+
+struct GeometryDecalCreateData {
+	NiPoint3		kWorldPos;
+	NiPoint3		kRotation;
+	NiPoint3		kPoint18;
+	void*			pActor = nullptr;
+	NiAVObject*		pNode = nullptr;
+	uint32_t		uiUnk2C = 0;
+	BGSTextureSet*	pTextureSet = nullptr;
+	int32_t			iIndex = -1;
+	float			fWidth = 0.0f;
+	float			fHeight = 0.0f;
+	float			fDepth = 0.0f;
+	float			fRNG = 1.0f;
+	TESObjectCELL*	pParentCell = nullptr;
+	float			fParallaxScale = 0.0f;
+	NiAVObject*		pSkinnedDecal = nullptr;
+	float			fSpecular = 0.0f;
+	float			fEpsilon = 0.0f;
+	float			fPlacementRadius = 0.0f;
+	float			fColorR = 0.0f;
+	float			fColorG = 0.0f;
+	float			fColorB = 0.0f;
+	uint32_t		uiHitLocationFlags = 0;
+	uint8_t			ucUVQuadrant = 0;
+	uint8_t			ucByte71 = 0;
+	uint8_t			ucByte72 = 0;
+	uint8_t			ucParallax = 0;
+	uint8_t			ucAlphaTest = 0;
+	uint8_t			ucAlphaBlend = 0;
+	uint8_t			ucParallaxPasses = 0;
+	uint8_t			ucModelSpace = 0;
+	uint8_t			ucForceFade = 0;
+	uint8_t			ucTwoSided = 0;
+	uint8_t			pad7A[2] = {};
+};
+static_assert(sizeof(GeometryDecalCreateData) == 0x7C);
+static_assert(offsetof(GeometryDecalCreateData, pTextureSet) == 0x30);
+static_assert(offsetof(GeometryDecalCreateData, pParentCell) == 0x48);
+static_assert(offsetof(GeometryDecalCreateData, uiHitLocationFlags) == 0x6C);
+
+static void AddActorBloodDecal(Actor* apTarget, NiAVObject* apNode, BGSImpactData* apImpact,
+                               int32_t aiLocation, const NiPoint3& arPos, const NiPoint3& arDir) {
+	void* pDecalManager = *reinterpret_cast<void**>(kAddrDecalManagerSingleton);
+	if (!pDecalManager || !apNode || !apImpact->textureSet)
+		return;
+
+	GeometryDecalCreateData kData;
+	kData.kWorldPos = arPos;
+	kData.kRotation = arDir;
+	kData.kPoint18 = arDir;
+	kData.pActor = apTarget;
+	kData.pNode = apNode;
+	kData.pTextureSet = apImpact->textureSet;
+	kData.fWidth = apImpact->decalMaxWidth;
+	kData.fHeight = apImpact->decalMaxHeight;
+	kData.fDepth = apImpact->decalDepth > 0.0f ? apImpact->decalDepth : 48.0f;
+	kData.pParentCell = apTarget->parentCell;
+	kData.fParallaxScale = apImpact->parallaxScale;
+	kData.fSpecular = apImpact->decalShininess;
+	kData.fEpsilon = apImpact->angleThreshold;
+	kData.fPlacementRadius = apImpact->placementRadius;
+	kData.fColorR = static_cast<float>(apImpact->decalColor & 0xFF) / 255.0f;
+	kData.fColorG = static_cast<float>((apImpact->decalColor >> 8) & 0xFF) / 255.0f;
+	kData.fColorB = static_cast<float>((apImpact->decalColor >> 16) & 0xFF) / 255.0f;
+	kData.uiHitLocationFlags = 1u << aiLocation;
+	kData.ucParallax = (apImpact->decalFlags & 1) ? 1 : 0;
+	kData.ucAlphaBlend = (apImpact->decalFlags & 2) ? 1 : 0;
+	kData.ucAlphaTest = (apImpact->decalFlags & 4) ? 1 : 0;
+	kData.ucParallaxPasses = apImpact->parallaxPasses;
+	kData.ucModelSpace = 1;
+
+	ThisCall(kAddrAddDecal, pDecalManager, &kData, 2, false);
+}
+
+static void SpawnActorHitFX(Actor* apTarget, Actor* apAttacker, TESObjectWEAP* apWeapon,
+                            int32_t aiLocation, int32_t aiMaterial, bool abBlood, bool abSound) {
+	if ((!abBlood && !abSound) || !apWeapon || !apWeapon->impactDataSet || !apTarget->parentCell)
+		return;
+	if (aiMaterial < 0 || aiMaterial >= ImpactSwap::eMT_Max)
+		return;
+	BGSImpactData* pImpact = apWeapon->impactDataSet->impactDatas[aiMaterial];
+	if (!pImpact)
+		return;
+
+	NiNode* pNode = nullptr;
+	const NiPoint3 kPos = GetActorHitWorldPos(apTarget, aiLocation, pNode);
+	const NiPoint3 kDir = HitFXDirection(apAttacker, kPos);
+
+	if (abBlood) {
+		PlayImpactParticle(apTarget->parentCell, pImpact, kPos, kDir);
+		AddActorBloodDecal(apTarget, pNode, pImpact, aiLocation, kPos, kDir);
+	}
+	if (abSound) {
+		PlayImpactSound(pImpact->sound1, kPos, pNode);
+		PlayImpactSound(pImpact->sound2, kPos, pNode);
+	}
+}
+
+static TESObjectWEAP* ResolveHitWeapon(TESForm* apForm) {
+	if (apForm)
+		return static_cast<TESObjectWEAP*>(apForm);
+	TESObjectWEAP* pDefault = const_cast<TESObjectWEAP*>(pDefaultUnarmedWeapon.Get());
+	return (pDefault && reinterpret_cast<TESForm*>(pDefault)->IsWeapon()) ? pDefault : nullptr;
+}
+
+}
+
+bool Cmd_ApplyHitData_Execute(COMMAND_ARGS) {
+	*result = 0;
+
+	Actor* pAttacker = nullptr;
+	float fHealth = 10.0f, fFatigue = 0.0f, fLimb = 0.0f;
+	TESForm* pWeaponForm = nullptr;
+	int32_t iHitLocation = 0;
+	uint32_t uiFlags = 0, bFireOnHit = 1, bFireAlarm = 1, bFireBlood = 1, bFireSound = 1, bSkipClear = 0;
+
+	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &pAttacker, &fHealth, &fFatigue, &fLimb, &pWeaponForm,
+			&iHitLocation, &uiFlags, &bFireOnHit, &bFireAlarm, &bFireBlood, &bFireSound, &bSkipClear))
+		return true;
+	if (!thisObj)
+		return true;
+	if (!IsFinite3(fHealth, fFatigue, fLimb) || fHealth < 0.0f || fFatigue < 0.0f || fLimb < 0.0f)
+		return true;
+
+	if (iHitLocation < -1 || iHitLocation > 13)
+		iHitLocation = -1;
+
+	Actor* pTarget = static_cast<Actor*>(thisObj);
+	if (!pTarget->IsActor() || !pTarget->baseProcess)
+		return true;
+	if (pAttacker && (!pAttacker->IsActor() || !pAttacker->baseProcess))
+		return true;
+	if (pWeaponForm && !pWeaponForm->IsWeapon())
+		return true;
+
+	TESObjectWEAP* pWeapon = ResolveHitWeapon(pWeaponForm);
+
+	ActorHitData kHit = {};
+	kHit.source = pAttacker;
+	kHit.target = pTarget;
+	kHit.unk0C = pWeapon ? pWeapon->weaponSkill : kAVCode_Unarmed;
+	kHit.hitLocation = iHitLocation;
+	kHit.healthDmg = fHealth;
+	kHit.wpnBaseDmg = fHealth;
+	kHit.fatigueDmg = fFatigue;
+	kHit.limbDmg = fLimb;
+	kHit.weapon = pWeapon;
+	kHit.healthPerc = pWeapon ? 1.0f : 0.0f;
+	kHit.impactPos = FallbackHitPos(pTarget, iHitLocation);
+	kHit.impactAngle = pAttacker
+		? HitFXDirection(pTarget, pAttacker->pos)
+		: NiPoint3(0.0f, 0.0f, 1.0f);
+	kHit.flags = uiFlags;
+	kHit.dmgMult = 1.0f;
+
+	BaseProcess* pProc = pTarget->baseProcess;
+	bool bCopiedHitData = false;
+	__try {
+		pProc->CopyHitData(&kHit);
+		bCopiedHitData = true;
+
+		if (fHealth > 0.0f) {
+			void** pVtbl = *reinterpret_cast<void***>(pTarget);
+			ThisCall(reinterpret_cast<uintptr_t>(pVtbl[kActorDamageVtableSlot]),
+				pTarget, fHealth, 0.0f, pAttacker);
+		}
+
+		if (fLimb > 0.0f && iHitLocation >= 0)
+			pTarget->DamageActorValue(BodyPartConditionAV(iHitLocation), -fLimb, pAttacker);
+
+		if (bFireOnHit) {
+			ExtraDataList* pExtra = &pTarget->extraDataList;
+			if (pAttacker)
+				CdeclCall(kAddrMergeScriptEvent, pAttacker, pExtra, 0x80);
+			if (pWeapon)
+				CdeclCall(kAddrMergeScriptEvent, pWeapon, pExtra, 0x100);
+		}
+
+		if (bFireAlarm && pAttacker &&
+				pAttacker == reinterpret_cast<Actor*>(PlayerCharacter::GetSingleton()))
+			ThisCall(kAddrSendAssaultAlarm, pTarget, pAttacker, 0, 0);
+
+		if (fFatigue > 0.0f)
+			pTarget->DamageActorValue(kAVCode_Fatigue, -fFatigue, pAttacker);
+
+		if (pWeaponForm && pWeapon && pWeapon->impactDataSet && (bFireBlood || bFireSound)) {
+			int32_t iBloodLoc = (iHitLocation >= 0) ? iHitLocation : 0;
+			int32_t iMaterial = GetActorBodyMaterial(pTarget);
+			if (iMaterial < 0)
+				iMaterial = ImpactSwap::eMT_Organic;
+			SpawnActorHitFX(pTarget, pAttacker, pWeapon, iBloodLoc, iMaterial, bFireBlood != 0, bFireSound != 0);
+		}
+
+		if (!bSkipClear) {
+			pProc->ResetHitData();
+			bCopiedHitData = false;
+		}
+
+		*result = 1;
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+		if (bCopiedHitData) {
+			__try {
+				pProc->ResetHitData();
+			}
+			__except (EXCEPTION_EXECUTE_HANDLER) {
+			}
+		}
+	}
+	return true;
+}
+
+namespace {
+
+static const float kGameToHavok = 0.142875f;
+
+struct __declspec(align(16)) PickRayData {
+	float		fFrom[4];
+	float		fTo[4];
+	uint8_t		ucEnableShapeCollectionFilter;
+	uint8_t		pad21[3];
+	uint32_t	uiFilterInfo;
+	uint32_t	pad28[6];
+	float		fHitFraction;
+	uint32_t	uiExtraInfo;
+	uint32_t	pad48[2];
+	uint32_t	uiShapeKeys[8];
+	int32_t		iShapeKeyIndex;
+	uint32_t	pad74[3];
+	void*		pRootCollidable;
+	uint32_t	pad84[3];
+	float		fLength[4];
+	char*		pCache;
+	void*		pClosestCollector;
+	void*		pAllCollector;
+	uint8_t		ucFailed;
+	uint8_t		padAD[3];
+};
+static_assert(sizeof(PickRayData) == 0xB0);
+static_assert(offsetof(PickRayData, fHitFraction) == 0x40);
+static_assert(offsetof(PickRayData, uiShapeKeys) == 0x50);
+static_assert(offsetof(PickRayData, pRootCollidable) == 0x80);
+static_assert(sizeof(hkCdBody) == 0x10);
+static_assert(offsetof(hkpWorldObject, cdBody) == 0x10);
+static_assert(offsetof(hkpWorldObject, collisionType) == 0x28);
+static_assert(offsetof(hkpShape, shape) == 0x08);
+static_assert(offsetof(bhkShape, unk10) == 0x10);
+static_assert(sizeof(bhkRefObject) == 0x0C);
+static_assert(offsetof(bhkRefObject, refObject) == 0x08);
+static_assert(sizeof(bhkNiCollisionObject) == 0x14);
+static_assert(offsetof(bhkNiCollisionObject, worldObj) == 0x10);
+
+struct CollisionFilter {
+	uint32_t uiFilter = 0;
+};
+static_assert(sizeof(CollisionFilter) == 4);
+
+static int32_t CollidableRootMaterial(const void* apCollidable, const NiPoint3* apPos) {
+	return ConvertHavokMaterial(CdeclCall<uint32_t>(
+		kAddrGetMaterialFromCollidable, apCollidable, apPos));
+}
+
+static bhkShape* ShapeGetBhk(const hkpShape* apHkpShape) {
+	return apHkpShape ? apHkpShape->shape : nullptr;
+}
+
+static int32_t BhkShapeMaterial(const bhkShape* apBhkShape) {
+	return apBhkShape ? ConvertHavokMaterial(apBhkShape->unk10) : -1;
+}
+
+static int32_t BhkShapeSubMaterial(bhkShape* apBhkShape, uint32_t auiShapeKey) {
+	return ConvertHavokMaterial(ThisCall<uint32_t>(
+		kAddrGetSubshapeMaterial, apBhkShape, auiShapeKey));
+}
+
+static void* HkpShapeContainer(void* apShape) {
+	if (!apShape)
+		return nullptr;
+	void** pVtbl = *reinterpret_cast<void***>(apShape);
+	return ThisCall<void*>(reinterpret_cast<uintptr_t>(
+		pVtbl[kShapeGetContainerVtableSlot]), apShape);
+}
+
+static void* HkpContainerChild(void* apContainer, uint32_t auiKey, void* apBuffer) {
+	if (!apContainer)
+		return nullptr;
+	void** pVtbl = *reinterpret_cast<void***>(apContainer);
+	return ThisCall<void*>(reinterpret_cast<uintptr_t>(
+		pVtbl[kShapeGetChildVtableSlot]), apContainer, auiKey, apBuffer);
+}
+
+static int32_t ChildShapeMaterial(void* apContainer, uint32_t auiKey, void* apBuffer) {
+	hkpShape* pChildShape = static_cast<hkpShape*>(HkpContainerChild(apContainer, auiKey, apBuffer));
+	bhkShape* pChildBhk = ShapeGetBhk(pChildShape);
+	return pChildBhk ? BhkShapeMaterial(pChildBhk) : -1;
+}
+
+struct MaterialCandidates {
+	int32_t iChildBest = -1;
+	int32_t iChildFallback = -1;
+	int32_t iSubBest = -1;
+	int32_t iSubFallback = -1;
+};
+
+static void NoteMaterialCandidate(int32_t aiMat, int32_t& arBest, int32_t& arFallback) {
+	if (aiMat > 0 && arBest < 0)
+		arBest = aiMat;
+	if (aiMat >= 0 && arFallback < 0)
+		arFallback = aiMat;
+}
+
+static void ProbeShapeKey(void* apContainer, bhkShape* apBhkShape, uint32_t auiKey,
+                          void* apChildBuffer, MaterialCandidates& arCandidates) {
+	if (auiKey == 0xFFFFFFFF)
+		return;
+	if (apContainer) {
+		NoteMaterialCandidate(ChildShapeMaterial(apContainer, auiKey, apChildBuffer),
+			arCandidates.iChildBest, arCandidates.iChildFallback);
+		if (arCandidates.iChildBest > 0)
+			return;
+	}
+	NoteMaterialCandidate(BhkShapeSubMaterial(apBhkShape, auiKey),
+		arCandidates.iSubBest, arCandidates.iSubFallback);
+}
+
+static uint32_t PlayerCollisionGroup() {
+	PlayerCharacter* pPlayer = PlayerCharacter::GetSingleton();
+	if (!pPlayer)
+		return 0;
+	CollisionFilter kFilter;
+	ThisCall(kAddrGetCollisionFilter, pPlayer, &kFilter);
+	return kFilter.uiFilter & 0xFFFF0000;
+}
+
+static int32_t ChooseMaterial(int32_t aiHitMat, const MaterialCandidates& arCandidates) {
+	if (arCandidates.iChildBest > 0)		return arCandidates.iChildBest;
+	if (arCandidates.iSubBest > 0)			return arCandidates.iSubBest;
+	if (aiHitMat > 0)						return aiHitMat;
+	if (arCandidates.iChildFallback >= 0)	return arCandidates.iChildFallback;
+	if (arCandidates.iSubFallback >= 0)		return arCandidates.iSubFallback;
+	return (aiHitMat >= 0) ? aiHitMat : -1;
+}
+
+static int32_t RaycastSubshapeMaterial(float afCamX, float afCamY, float afCamZ,
+                                       float afHitX, float afHitY, float afHitZ, int32_t aiLayer) {
+	PickRayData kPick = {};
+	kPick.fFrom[0] = afCamX * kGameToHavok;
+	kPick.fFrom[1] = afCamY * kGameToHavok;
+	kPick.fFrom[2] = afCamZ * kGameToHavok;
+	const double fEndX64 = afCamX + (static_cast<double>(afHitX) - afCamX) * 1.05;
+	const double fEndY64 = afCamY + (static_cast<double>(afHitY) - afCamY) * 1.05;
+	const double fEndZ64 = afCamZ + (static_cast<double>(afHitZ) - afCamZ) * 1.05;
+	if (!std::isfinite(fEndX64) || !std::isfinite(fEndY64) || !std::isfinite(fEndZ64) ||
+			std::fabs(fEndX64) > std::numeric_limits<float>::max() ||
+			std::fabs(fEndY64) > std::numeric_limits<float>::max() ||
+			std::fabs(fEndZ64) > std::numeric_limits<float>::max())
+		return -1;
+	const float fEndX = static_cast<float>(fEndX64);
+	const float fEndY = static_cast<float>(fEndY64);
+	const float fEndZ = static_cast<float>(fEndZ64);
+	kPick.fTo[0] = fEndX * kGameToHavok;
+	kPick.fTo[1] = fEndY * kGameToHavok;
+	kPick.fTo[2] = fEndZ * kGameToHavok;
+	if (!IsFinite3(kPick.fFrom[0], kPick.fFrom[1], kPick.fFrom[2]) ||
+			!IsFinite3(kPick.fTo[0], kPick.fTo[1], kPick.fTo[2]))
+		return -1;
+	kPick.fHitFraction = 1.0f;
+	kPick.uiExtraInfo = 0xFFFFFFFF;
+	kPick.uiShapeKeys[0] = 0xFFFFFFFF;
+
+	__try {
+		kPick.uiFilterInfo = static_cast<uint32_t>(aiLayer) | PlayerCollisionGroup();
+
+		TES* pTES = TES::GetSingleton();
+		if (!pTES)
+			return -1;
+		if (!ThisCall<void*>(kAddrPick, pTES, &kPick, 1))
+			return -1;
+
+		void* pRoot = kPick.pRootCollidable;
+		if (!pRoot)
+			return -1;
+
+		float fFrac = kPick.fHitFraction;
+		if (fFrac < 0.0f || fFrac > 1.0f)
+			fFrac = 1.0f;
+
+		const double fPickX = afCamX + (fEndX64 - afCamX) * fFrac;
+		const double fPickY = afCamY + (fEndY64 - afCamY) * fFrac;
+		const double fPickZ = afCamZ + (fEndZ64 - afCamZ) * fFrac;
+		if (!std::isfinite(fPickX) || !std::isfinite(fPickY) || !std::isfinite(fPickZ) ||
+				std::fabs(fPickX) > std::numeric_limits<float>::max() ||
+				std::fabs(fPickY) > std::numeric_limits<float>::max() ||
+				std::fabs(fPickZ) > std::numeric_limits<float>::max())
+			return -1;
+		NiPoint3 kHitPos(
+			static_cast<float>(fPickX),
+			static_cast<float>(fPickY),
+			static_cast<float>(fPickZ));
+		ThisCall(kAddrCalcPickHitPoint, &kPick, &kHitPos);
+		if (!IsFinite3(kHitPos.x, kHitPos.y, kHitPos.z))
+			return -1;
+
+		const int32_t iHitMat = CollidableRootMaterial(pRoot, &kHitPos);
+
+		hkpShape* pRootShape = *reinterpret_cast<hkpShape**>(pRoot);
+		bhkShape* pBhkShape = ShapeGetBhk(pRootShape);
+		MaterialCandidates kCandidates;
+		if (pBhkShape) {
+			void* pContainer = HkpShapeContainer(pRootShape);
+			__declspec(align(16)) uint8_t kChildBuffer[512];
+			void* pChildBuffer = nullptr;
+			if (pContainer) {
+				std::memset(kChildBuffer, 0, sizeof(kChildBuffer));
+				pChildBuffer = kChildBuffer;
+			}
+			for (int32_t i = 1; i <= 7; ++i) {
+				ProbeShapeKey(pContainer, pBhkShape, kPick.uiShapeKeys[i], pChildBuffer, kCandidates);
+				if (kCandidates.iChildBest > 0)
+					break;
+			}
+			if (kCandidates.iChildBest <= 0)
+				ProbeShapeKey(pContainer, pBhkShape, kPick.uiShapeKeys[0], pChildBuffer, kCandidates);
+		}
+
+		int32_t iChosen = ChooseMaterial(iHitMat, kCandidates);
+		if (iChosen < 0) {
+			NiPoint3 kScriptHitPos(afHitX, afHitY, afHitZ);
+			const int32_t iScriptMat = CollidableRootMaterial(pRoot, &kScriptHitPos);
+			if (iScriptMat >= 0)
+				iChosen = iScriptMat;
+		}
+		return iChosen;
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+		return -1;
+	}
+}
+
+struct HavokRecData {
+	void*		pWorld = nullptr;
+	uint8_t		ucRecurse = 0;
+	uint8_t		pad05[3] = {};
+	uint32_t	uiAction = 0;
+	uint32_t	uiData0 = 0;
+	uint32_t	uiData1 = 0;
+	int32_t		iOutMaterial = -1;
+	uint32_t	uiData3 = 0;
+};
+static_assert(sizeof(HavokRecData) == 0x1C);
+static_assert(offsetof(HavokRecData, uiAction) == 0x08);
+static_assert(offsetof(HavokRecData, iOutMaterial) == 0x14);
+
+static int32_t CollisionObjectMaterial(void* apCollisionObject) {
+	if (!apCollisionObject)
+		return -1;
+	bhkNiCollisionObject* pCollision = static_cast<bhkNiCollisionObject*>(apCollisionObject);
+	if (!pCollision->worldObj || !pCollision->worldObj->refObject)
+		return -1;
+	hkpWorldObject* pBody = static_cast<hkpWorldObject*>(pCollision->worldObj->refObject);
+	hkpShape* pShape = static_cast<hkpShape*>(pBody->cdBody.shape);
+	if (!pShape || !pShape->shape)
+		return -1;
+	return ConvertHavokMaterial(pShape->shape->unk10); // unk10 = havok material
+}
+
+static void __cdecl FirstMaterialCallback(void* apCollisionObject, HavokRecData* apData) {
+	if (!apData || apData->iOutMaterial >= 0)
+		return;
+	const int32_t iMat = CollisionObjectMaterial(apCollisionObject);
+	if (iMat >= 0)
+		apData->iOutMaterial = iMat;
+}
+
+static int32_t GetObjectImpactMaterial(TESObjectREFR* apRef) {
+	if (apRef->IsActor())
+		return GetActorBodyMaterial(apRef);
+
+	NiAVObject* pRoot = apRef->Get3D();
+	if (!pRoot)
+		return -1;
+	HavokRecData kData;
+	kData.ucRecurse = 1;
+	kData.uiAction = 8;
+	__try {
+		CdeclCall(kAddrVisitHavokObjects, pRoot, &kData, FirstMaterialCallback);
+		if (kData.iOutMaterial < 0)
+			kData.iOutMaterial = CollisionObjectMaterial(pRoot->m_spCollisionObject);
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+		return -1;
+	}
+	return kData.iOutMaterial;
+}
+
+}
+
+bool Cmd_GetObjectMaterial_Execute(COMMAND_ARGS) {
+	*result = -1;
+	float fCamX = 3.0e38f, fCamY = 0.0f, fCamZ = 0.0f, fHitX = 0.0f, fHitY = 0.0f, fHitZ = 0.0f;
+	int32_t iLayer = 6;
+	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &fCamX, &fCamY, &fCamZ, &fHitX, &fHitY, &fHitZ, &iLayer))
+		return true;
+	if (!thisObj)
+		return true;
+
+	if (!std::isfinite(fCamX))
+		return true;
+	if (fCamX < 1.0e38f) {
+		if (!IsFinite3(fCamX, fCamY, fCamZ) || !IsFinite3(fHitX, fHitY, fHitZ) ||
+				iLayer < 0 || iLayer > 0x7F)
+			return true;
+		*result = RaycastSubshapeMaterial(fCamX, fCamY, fCamZ, fHitX, fHitY, fHitZ, iLayer);
+	} else {
+		*result = GetObjectImpactMaterial(thisObj);
+	}
+	return true;
+}
+
+bool Cmd_ApplyObjectImpact_Execute(COMMAND_ARGS) {
+	*result = -1;
+
+	int32_t iMaterial = -1;
+	TESForm* pWeaponForm = nullptr;
+	uint32_t bSound = 1, bParticle = 1;
+	float fPosX = 3.0e38f, fPosY = 3.0e38f, fPosZ = 3.0e38f;
+
+	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &iMaterial, &pWeaponForm, &bSound, &bParticle, &fPosX, &fPosY, &fPosZ))
+		return true;
+	if (!thisObj)
+		return true;
+	if (pWeaponForm && !pWeaponForm->IsWeapon())
+		return true;
+	if (!IsFinite3(fPosX, fPosY, fPosZ))
+		return true;
+
+	__try {
+		TESObjectWEAP* pWeapon = ResolveHitWeapon(pWeaponForm);
+		if (!pWeapon || !pWeapon->impactDataSet)
+			return true;
+
+		if (iMaterial < 0)
+			iMaterial = GetObjectImpactMaterial(thisObj);
+		if (iMaterial < 0 || iMaterial >= ImpactSwap::eMT_Max)
+			return true;
+
+		BGSImpactData* pImpact = pWeapon->impactDataSet->impactDatas[iMaterial];
+		if (!pImpact)
+			return true;
+
+		NiPoint3 kPos = (fPosX > 1.0e38f || fPosY > 1.0e38f || fPosZ > 1.0e38f)
+			? thisObj->pos
+			: NiPoint3(fPosX, fPosY, fPosZ);
+		const NiPoint3 kDir = HitFXDirection(
+			reinterpret_cast<Actor*>(PlayerCharacter::GetSingleton()), kPos);
+
+		if (bParticle)
+			PlayImpactParticle(thisObj->parentCell, pImpact, kPos, kDir);
+		if (bSound) {
+			PlayImpactSound(pImpact->sound1, kPos, nullptr);
+			PlayImpactSound(pImpact->sound2, kPos, nullptr);
+		}
+		*result = iMaterial;
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+	}
+	return true;
+}
+
+bool Cmd_InterruptWeaponAnim_Execute(COMMAND_ARGS) {
+	*result = -2;
+	if (!thisObj)
+		return true;
+	Actor* pActor = static_cast<Actor*>(thisObj);
+	if (!pActor->IsActor() || !pActor->baseProcess)
+		return true;
+	if (pActor->baseProcess->processLevel != 0)
+		return true;
+	HighProcess* pProc = static_cast<HighProcess*>(pActor->baseProcess);
+
+	Animation* pAnimation = pProc->animData;
+	if (!pAnimation)
+		return true;
+
+	const int16_t sOldAction = pProc->currentAction;
+	// Never clear an attack sequence. The queued melee task does not null-check it.
+	if (sOldAction >= HighProcess::kAnimAction_Attack && sOldAction <= HighProcess::kAnimAction_Attack_Throw_Release) {
+		*result = -3;
+		return true;
+	}
+
+	__try {
+		for (int32_t iSeq = 4; iSeq <= 6; ++iSeq) {
+			if (BSAnimGroupSequence* pSequence = pAnimation->animSequence[iSeq])
+				if (pAnimation->unk0D8)
+					pAnimation->unk0D8->DeactivateSequence(pSequence, 0.0f);
+			ThisCall(kAddrClearAnimGroup, pAnimation, iSeq, 0.0f);
+		}
+		ThisCall(kAddrSetAnimActionAndSequence, pActor, -1, nullptr);
+		*result = sOldAction;
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+	}
+	return true;
+}
+
+namespace {
+
+static const float kHavokToGame = 6.99903965f;
+static_assert(sizeof(hkpWorldObject) == 0x8C);
+static_assert(sizeof(hkpMotion) == 0x140);
+static_assert(offsetof(hkpMotion, linVelocity) == 0xD0);
+static_assert(sizeof(hkpRigidBody) == 0x220);
+static_assert(offsetof(hkpRigidBody, motion) == 0xE0);
+static_assert(sizeof(bhkWorldObject) == 0x14);
+static_assert(offsetof(bhkWorldObject, refObject) == 0x08);
+static_assert(sizeof(bhkRigidBody) == 0x1C);
+
+static float* GetRigidBodyCenterOfMass(bhkWorldObject* apWorldObject, float* apOut) {
+	void** pVtbl = *reinterpret_cast<void***>(apWorldObject);
+	return ThisCall<float*>(reinterpret_cast<uintptr_t>(
+		pVtbl[kRigidBodyCenterVtableSlot]), apWorldObject, apOut);
+}
+
+static void PushNodeBodies(NiAVObject* apObject, uint32_t auiDepth,
+                           float afOriginX, float afOriginY, float afOriginZ,
+                           float afForce, uint32_t& arCount) {
+	if (!apObject || auiDepth > 64)
+		return;
+	NiNode* pNode = apObject->IsNode();
+	if (!pNode)
+		return;
+
+	bhkNiCollisionObject* pCollision = pNode->m_spCollisionObject;
+	bhkWorldObject* pWorldObj = pCollision ? pCollision->worldObj : nullptr;
+	hkpRigidBody* pRigid = pWorldObj ? static_cast<hkpRigidBody*>(pWorldObj->refObject) : nullptr;
+	if (pRigid && pRigid->collisionType == 1) {
+		__declspec(align(16)) float kBodyPos[4];
+		float* pPos = GetRigidBodyCenterOfMass(pWorldObj, kBodyPos);
+		if (pPos && IsFinite3(pPos[0], pPos[1], pPos[2])) {
+			double fDX = static_cast<double>(pPos[0]) * kHavokToGame - afOriginX;
+			double fDY = static_cast<double>(pPos[1]) * kHavokToGame - afOriginY;
+			double fDZ = static_cast<double>(pPos[2]) * kHavokToGame - afOriginZ;
+			if (fDZ > 0.0)
+				fDZ = 0.0;
+			const double fLen = std::sqrt(fDX * fDX + fDY * fDY + fDZ * fDZ);
+			if (std::isfinite(fLen) && fLen > 0.0001) {
+				const double fScale = static_cast<double>(afForce) * kGameToHavok / fLen;
+				NiPoint4 kVelocity = pRigid->motion.linVelocity;
+				const float fNewX = static_cast<float>(kVelocity.x + fDX * fScale);
+				const float fNewY = static_cast<float>(kVelocity.y + fDY * fScale);
+				const float fNewZ = static_cast<float>(kVelocity.z + fDZ * fScale);
+				if (IsFinite3(kVelocity.x, kVelocity.y, kVelocity.z) &&
+						std::isfinite(kVelocity.w) && IsFinite3(fNewX, fNewY, fNewZ)) {
+					kVelocity.x = fNewX;
+					kVelocity.y = fNewY;
+					kVelocity.z = fNewZ;
+					ThisCall(kAddrSetRigidBodyLinearVelocity, pWorldObj, &kVelocity);
+					++arCount;
+				}
+			}
+		}
+	}
+
+	const uint32_t uiChildCount = pNode->GetArrayCount();
+	if (uiChildCount > 1024)
+		return;
+	for (uint32_t i = 0; i < uiChildCount; ++i)
+		if (NiAVObject* pChild = pNode->GetAt(i))
+			PushNodeBodies(pChild, auiDepth + 1, afOriginX, afOriginY, afOriginZ, afForce, arCount);
+}
+
+}
+
+bool Cmd_ApplyRagdollForce_Execute(COMMAND_ARGS) {
+	*result = 0;
+	float fForce = 0.0f, fOriginX = 0.0f, fOriginY = 0.0f, fOriginZ = 0.0f;
+	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &fForce, &fOriginX, &fOriginY, &fOriginZ))
+		return true;
+	if (!thisObj)
+		return true;
+	if (!std::isfinite(fForce) || !IsFinite3(fOriginX, fOriginY, fOriginZ) || fForce == 0.0f)
+		return true;
+	Actor* pActor = static_cast<Actor*>(thisObj);
+	if (!pActor->IsActor() || !pActor->baseProcess)
+		return true;
+	// Get3DSimple, not Get3D. The player override returns the 1st person arms in 1st person.
+	NiAVObject* pRoot = pActor->Get3DSimple();
+	if (!pRoot)
+		return true;
+	uint32_t uiCount = 0;
+	__try {
+		PushNodeBodies(pRoot, 0, fOriginX, fOriginY, fOriginZ, fForce, uiCount);
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+		return true;
+	}
+	*result = uiCount;
+	return true;
+}
+
+bool Cmd_Set3rdPersonOverlay_Execute(COMMAND_ARGS) {
+	*result = PlayerBodyOverlay::IsEnabled() ? 1 : 0;
+	uint32_t bEnable = 0;
+	int32_t iDisableSuppressFrames = -1;
+	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &bEnable, &iDisableSuppressFrames))
+		return true;
+	*result = PlayerBodyOverlay::SetEnabled(bEnable != 0, iDisableSuppressFrames);
+	return true;
+}
+
+bool Cmd_Set3rdPersonOverlayCullParts_Execute(COMMAND_ARGS) {
+	*result = PlayerBodyOverlay::GetCullPartBits();
+	int32_t iMode = 0;
+	int32_t kParts[16];
+	for (int32_t i = 0; i < 16; ++i)
+		kParts[i] = -1;
+	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &iMode,
+			&kParts[0], &kParts[1], &kParts[2], &kParts[3],
+			&kParts[4], &kParts[5], &kParts[6], &kParts[7],
+			&kParts[8], &kParts[9], &kParts[10], &kParts[11],
+			&kParts[12], &kParts[13], &kParts[14], &kParts[15]))
+		return true;
+
+	const uint32_t uiBits = (iMode >= 1 && iMode <= 2) ? PlayerBodyOverlay::BuildPartBits(kParts, 16) : 0;
+	PlayerBodyOverlay::SetCullParts(iMode, uiBits);
+	*result = PlayerBodyOverlay::GetCullPartBits();
+	return true;
+}

--- a/JG/functions/fn_hit.cpp
+++ b/JG/functions/fn_hit.cpp
@@ -23,23 +23,16 @@ namespace {
 
 using ImpactSwap = TESWorldSpace::ImpactSwap;
 
-static_assert(BHK_MATERIAL_MASK_FIXED == 0x3F);
-
 constexpr uintptr_t kAddrCreateTempEffectParticle = 0x6890B0;
 constexpr uintptr_t kAddrDecalManagerSingleton = 0x11C57F8;
-constexpr uintptr_t kAddrAddDecal = 0x4A10D0;
 constexpr uintptr_t kAddrMergeScriptEvent = 0x5AC750;
 constexpr uintptr_t kAddrSendAssaultAlarm = 0x8C0460;
 constexpr uintptr_t kAddrGetMaterialFromCollidable = 0x62B150;
-constexpr uintptr_t kAddrGetSubshapeMaterial = 0xC84F10;
 constexpr uintptr_t kAddrGetCollisionFilter = 0x931ED0;
 constexpr uintptr_t kAddrPick = 0x458440;
 constexpr uintptr_t kAddrCalcPickHitPoint = 0x5DBE60;
 constexpr uintptr_t kAddrVisitHavokObjects = 0xC68900;
-constexpr uintptr_t kAddrClearAnimGroup = 0x496080;
-constexpr uintptr_t kAddrSetAnimActionAndSequence = 0x8A73E0;
 constexpr uintptr_t kAddrSetRigidBodyLinearVelocity = 0x561690;
-constexpr uint32_t kActorDamageVtableSlot = 0xCE;
 constexpr uint32_t kShapeGetContainerVtableSlot = 4;
 constexpr uint32_t kShapeGetChildVtableSlot = 5;
 constexpr uint32_t kRigidBodyCenterVtableSlot = 0xF0 / 4;
@@ -107,160 +100,73 @@ static bool IsFinite3(float afX, float afY, float afZ) {
 	return std::isfinite(afX) && std::isfinite(afY) && std::isfinite(afZ);
 }
 
-static uint32_t BodyPartConditionAV(int32_t aiLocation) {
-	switch (aiLocation) {
-		case 1: case 2:				return kAVCode_PerceptionCondition;
-		case 3: case 4:				return kAVCode_LeftAttackCondition;
-		case 5: case 6:				return kAVCode_RightAttackCondition;
-		case 7: case 8: case 9:		return kAVCode_LeftMobilityCondition;
-		case 10: case 11: case 12:	return kAVCode_RightMobilityCondition;
-		case 13:					return kAVCode_BrainCondition;
-		default:					return kAVCode_EnduranceCondition;
-	}
-}
-
-static const char* BodyPartNodeName(int32_t aiLocation) {
-	switch (aiLocation) {
-		case 1: case 2: case 13:	return "Bip01 Head";
-		case 3:						return "Bip01 L UpperArm";
-		case 4:						return "Bip01 L Forearm";
-		case 5:						return "Bip01 R UpperArm";
-		case 6:						return "Bip01 R Forearm";
-		case 7:						return "Bip01 L Thigh";
-		case 8:						return "Bip01 L Calf";
-		case 9:						return "Bip01 L Foot";
-		case 10:					return "Bip01 R Thigh";
-		case 11:					return "Bip01 R Calf";
-		case 12:					return "Bip01 R Foot";
-		default:					return "Bip01 Spine2";
-	}
-}
-
-static float BodyPartZOffset(int32_t aiLocation) {
-	switch (aiLocation) {
-		case 1: case 2: case 13:	return 120.0f;
-		case 3: case 5:				return 100.0f;
-		case 4: case 6:				return 85.0f;
-		case 7: case 10:			return 50.0f;
-		case 8: case 11:			return 25.0f;
-		case 9: case 12:			return 5.0f;
-		default:					return 80.0f;
-	}
-}
-
-static NiPoint3 FallbackHitPos(Actor* apActor, int32_t aiLocation) {
-	const NiPoint3& kPos = apActor->pos;
-	return NiPoint3(kPos.x, kPos.y, kPos.z + BodyPartZOffset(aiLocation));
-}
-
-static NiPoint3 GetActorHitWorldPos(Actor* apActor, int32_t aiLocation, NiNode*& arRootOut) {
+static NiPoint3 GetActorHitWorldPos(Actor* apActor, BODY_PART_TYPE aeLocation, NiNode** appRootOut) {
 	// Get3DSimple, not Get3D. The player override returns the 1st person arms in 1st person.
-	arRootOut = apActor->Get3DSimple();
-	if (arRootOut) {
-		if (NiAVObject* pBone = BSUtilities::GetObjectByName(arRootOut, BodyPartNodeName(aiLocation)))
+	NiNode* pScene = apActor->Get3DSimple();
+	if (appRootOut)
+		*appRootOut = pScene;
+	if (pScene) {
+		NiAVObject* pBone = apActor->baseProcess->GetDamageNode(aeLocation);
+		if (pBone)
 			return pBone->m_kWorld.m_kTranslate;
+
+		return pScene->m_kWorld.m_kTranslate;
 	}
-	return FallbackHitPos(apActor, aiLocation);
+
+	return NiPoint3::ZERO;
 }
 
 static NiPoint3 HitFXDirection(Actor* apAttacker, const NiPoint3& arPos) {
 	if (!apAttacker)
-		return NiPoint3(0.0f, 1.0f, 0.0f);
+		return NiPoint3::UNIT_Y;
+
 	NiPoint3 kDir = apAttacker->pos - arPos;
-	if (!IsFinite3(kDir.x, kDir.y, kDir.z))
-		return NiPoint3(0.0f, 1.0f, 0.0f);
-	const double fLenSq =
-		static_cast<double>(kDir.x) * kDir.x +
-		static_cast<double>(kDir.y) * kDir.y +
-		static_cast<double>(kDir.z) * kDir.z;
-	if (!std::isfinite(fLenSq) || fLenSq <= 0.00000001)
-		return NiPoint3(0.0f, 1.0f, 0.0f);
-	const float fInvLen = static_cast<float>(1.0 / std::sqrt(fLenSq));
-	kDir.x *= fInvLen;
-	kDir.y *= fInvLen;
-	kDir.z *= fInvLen;
+	kDir.Unitize();
+	if (kDir == NiPoint3::ZERO)
+		return NiPoint3::UNIT_Y;
 	return kDir;
 }
 
-// Keep the 0x3F mask. The engine helper drops materials 32 through 35.
-static int32_t ConvertHavokMaterial(uint32_t auiRaw) {
-	switch (static_cast<HavokMaterialType>(auiRaw & BHK_MATERIAL_MASK_FIXED)) {
-		case BHK_MATERIAL_STONE:
-		case BHK_MATERIAL_HEAVYSTONE:
-		case BHK_MATERIAL_BROKENCONCRETE:		return ImpactSwap::eMT_Stone;
-		case BHK_MATERIAL_DIRT:
-		case BHK_MATERIAL_SAND:					return ImpactSwap::eMT_Dirt;
-		case BHK_MATERIAL_GRASS:				return ImpactSwap::eMT_Grass;
-		case BHK_MATERIAL_GLASS:
-		case BHK_MATERIAL_BOTTLE:				return ImpactSwap::eMT_Glass;
-		case BHK_MATERIAL_METAL:
-		case BHK_MATERIAL_HEAVYMETAL:
-		case BHK_MATERIAL_CHAIN:
-		case BHK_MATERIAL_SNOW:
-		case BHK_MATERIAL_ELEVATOR:
-		case BHK_MATERIAL_VEHICLEBODY:
-		case BHK_MATERIAL_VEHICLEPARTSOLID:
-		case BHK_MATERIAL_PISTOL:
-		case BHK_MATERIAL_RIFLE:
-		case BHK_MATERIAL_CHAINLINK:			return ImpactSwap::eMT_Metal;
-		case BHK_MATERIAL_WOOD:
-		case BHK_MATERIAL_HEAVYWOOD:
-		case BHK_MATERIAL_BABYRATTLE:
-		case BHK_MATERIAL_RUBBERBALL:			return ImpactSwap::eMT_Wood;
-		case BHK_MATERIAL_ORGANIC:
-		case BHK_MATERIAL_SKIN:					return ImpactSwap::eMT_Organic;
-		case BHK_MATERIAL_CLOTH:
-		case BHK_MATERIAL_CARPET:				return ImpactSwap::eMT_Cloth;
-		case BHK_MATERIAL_WATER:				return ImpactSwap::eMT_Water;
-		case BHK_MATERIAL_HOLLOWMETAL:
-		case BHK_MATERIAL_SHEETMETAL:
-		case BHK_MATERIAL_VEHICLEPARTHOLLOW:
-		case BHK_MATERIAL_BARREL:
-		case BHK_MATERIAL_SODACAN:
-		case BHK_MATERIAL_SHOPPINGCART:
-		case BHK_MATERIAL_LUNCHBOX:				return ImpactSwap::eMT_HollowMetal;
-		case BHK_MATERIAL_TILE:					return ImpactSwap::eMT_Stone;
-		case BHK_MATERIAL_TUMBLEWEED:			return ImpactSwap::eMT_Dirt;
-		default:								return -1;
-	}
+static int32_t MaterialTypeToImpactData(uint32_t aeHavokMaterial) {
+	return CdeclCall<int32_t>(0x58E8F0, aeHavokMaterial);
 }
 
-static int32_t GetActorBodyMaterial(TESObjectREFR* apRef) {
-	TESBoundObject* pBase = apRef->baseForm;
+static int32_t __fastcall GetActorBodyMaterial(Actor* apActor) {
+	TESActorBase* pBase = static_cast<TESActorBase*>(apActor->baseForm);
 	if (!pBase)
 		return -1;
-	int32_t iMat = -1;
-	if (pBase->eFormType == FORM_TYPE::TESNPC)
-		iMat = static_cast<int32_t>(static_cast<TESNPC*>(pBase)->impactMaterialType);
-	else if (pBase->eFormType == FORM_TYPE::TESCreature)
-		iMat = static_cast<int32_t>(static_cast<TESCreature*>(pBase)->materialType);
-	return (iMat >= 0 && iMat < ImpactSwap::eMT_Max) ? iMat : -1;
+
+	return pBase->baseData.GetBloodImpactMaterial();
 }
 
 static void PlayImpactSound(TESSound* apSound, const NiPoint3& arPos, NiAVObject* apNode) {
 	if (!apSound || !apSound->uiFormID)
 		return;
+	
 	BSWin32Audio* pAudio = BSWin32Audio::GetSingleton();
 	if (!pAudio)
 		return;
-	BSSoundHandle kHandle = pAudio->GetSoundHandleByFormID(
-		apSound->uiFormID, BSAudioManager::kAudioFlags_3D | BSAudioManager::kAudioFlags_100);
+
+	BSSoundHandle kHandle = pAudio->GetSoundHandleByFormID(apSound->uiFormID, BSAudioManager::kAudioFlags_3D | BSAudioManager::kAudioFlags_100);
 	if (kHandle.uiSoundID == 0xFFFFFFFF)
 		return;
+
 	kHandle.SetPosition(arPos);
 	if (apNode)
 		kHandle.SetObjectToFollow(apNode);
+
 	kHandle.Play(false);
 }
 
 static void PlayImpactParticle(TESObjectCELL* apCell, BGSImpactData* apImpact, const NiPoint3& arPos, const NiPoint3& arDir) {
 	if (!apCell)
 		return;
+
 	const char* pModelPath = apImpact->model.GetModel();
 	if (!pModelPath || !pModelPath[0])
 		return;
-	CdeclCall(kAddrCreateTempEffectParticle, apCell, apImpact->effectDuration,
-		pModelPath, arDir, arPos, 1.0f, 7, nullptr);
+
+	CdeclCall(kAddrCreateTempEffectParticle, apCell, apImpact->effectDuration, pModelPath, arDir, arPos, 1.f, 7, nullptr);
 }
 
 struct GeometryDecalCreateData {
@@ -272,19 +178,19 @@ struct GeometryDecalCreateData {
 	uint32_t		uiUnk2C = 0;
 	BGSTextureSet*	pTextureSet = nullptr;
 	int32_t			iIndex = -1;
-	float			fWidth = 0.0f;
-	float			fHeight = 0.0f;
-	float			fDepth = 0.0f;
-	float			fRNG = 1.0f;
+	float			fWidth = 0.f;
+	float			fHeight = 0.f;
+	float			fDepth = 0.f;
+	float			fRNG = 1.f;
 	TESObjectCELL*	pParentCell = nullptr;
-	float			fParallaxScale = 0.0f;
+	float			fParallaxScale = 0.f;
 	NiAVObject*		pSkinnedDecal = nullptr;
-	float			fSpecular = 0.0f;
-	float			fEpsilon = 0.0f;
-	float			fPlacementRadius = 0.0f;
-	float			fColorR = 0.0f;
-	float			fColorG = 0.0f;
-	float			fColorB = 0.0f;
+	float			fSpecular = 0.f;
+	float			fEpsilon = 0.f;
+	float			fPlacementRadius = 0.f;
+	float			fColorR = 0.f;
+	float			fColorG = 0.f;
+	float			fColorB = 0.f;
 	uint32_t		uiHitLocationFlags = 0;
 	uint8_t			ucUVQuadrant = 0;
 	uint8_t			ucByte71 = 0;
@@ -303,10 +209,8 @@ static_assert(offsetof(GeometryDecalCreateData, pTextureSet) == 0x30);
 static_assert(offsetof(GeometryDecalCreateData, pParentCell) == 0x48);
 static_assert(offsetof(GeometryDecalCreateData, uiHitLocationFlags) == 0x6C);
 
-static void AddActorBloodDecal(Actor* apTarget, NiAVObject* apNode, BGSImpactData* apImpact,
-                               int32_t aiLocation, const NiPoint3& arPos, const NiPoint3& arDir) {
-	void* pDecalManager = *reinterpret_cast<void**>(kAddrDecalManagerSingleton);
-	if (!pDecalManager || !apNode || !apImpact->textureSet)
+static void AddActorBloodDecal(Actor* apTarget, NiAVObject* apNode, BGSImpactData* apImpact, int32_t aiLocation, const NiPoint3& arPos, const NiPoint3& arDir) {
+	if (!apNode || !apImpact->textureSet || !apTarget->parentCell)
 		return;
 
 	GeometryDecalCreateData kData;
@@ -318,15 +222,14 @@ static void AddActorBloodDecal(Actor* apTarget, NiAVObject* apNode, BGSImpactDat
 	kData.pTextureSet = apImpact->textureSet;
 	kData.fWidth = apImpact->decalMaxWidth;
 	kData.fHeight = apImpact->decalMaxHeight;
-	kData.fDepth = apImpact->decalDepth > 0.0f ? apImpact->decalDepth : 48.0f;
-	kData.pParentCell = apTarget->parentCell;
+	kData.fDepth = apImpact->decalDepth > 0.f ? apImpact->decalDepth : 48.f;
 	kData.fParallaxScale = apImpact->parallaxScale;
 	kData.fSpecular = apImpact->decalShininess;
 	kData.fEpsilon = apImpact->angleThreshold;
 	kData.fPlacementRadius = apImpact->placementRadius;
-	kData.fColorR = static_cast<float>(apImpact->decalColor & 0xFF) / 255.0f;
-	kData.fColorG = static_cast<float>((apImpact->decalColor >> 8) & 0xFF) / 255.0f;
-	kData.fColorB = static_cast<float>((apImpact->decalColor >> 16) & 0xFF) / 255.0f;
+	kData.fColorR = static_cast<float>(apImpact->decalColor & 0xFF) / 255.f;
+	kData.fColorG = static_cast<float>((apImpact->decalColor >> 8) & 0xFF) / 255.f;
+	kData.fColorB = static_cast<float>((apImpact->decalColor >> 16) & 0xFF) / 255.f;
 	kData.uiHitLocationFlags = 1u << aiLocation;
 	kData.ucParallax = (apImpact->decalFlags & 1) ? 1 : 0;
 	kData.ucAlphaBlend = (apImpact->decalFlags & 2) ? 1 : 0;
@@ -334,24 +237,25 @@ static void AddActorBloodDecal(Actor* apTarget, NiAVObject* apNode, BGSImpactDat
 	kData.ucParallaxPasses = apImpact->parallaxPasses;
 	kData.ucModelSpace = 1;
 
-	ThisCall(kAddrAddDecal, pDecalManager, &kData, 2, false);
+	ThisCall(0x4A3FE0, apTarget->parentCell, &kData, 2, false);
 }
 
-static void SpawnActorHitFX(Actor* apTarget, Actor* apAttacker, TESObjectWEAP* apWeapon,
-                            int32_t aiLocation, int32_t aiMaterial, bool abBlood, bool abSound) {
+static void SpawnActorHitFX(Actor* apTarget, Actor* apAttacker, TESObjectWEAP* apWeapon, BODY_PART_TYPE aiLocation, int32_t aiMaterial, bool abBlood, bool abSound) {
 	if ((!abBlood && !abSound) || !apWeapon || !apWeapon->impactDataSet || !apTarget->parentCell)
 		return;
+
 	if (aiMaterial < 0 || aiMaterial >= ImpactSwap::eMT_Max)
 		return;
+
 	BGSImpactData* pImpact = apWeapon->impactDataSet->impactDatas[aiMaterial];
 	if (!pImpact)
 		return;
 
 	NiNode* pNode = nullptr;
-	const NiPoint3 kPos = GetActorHitWorldPos(apTarget, aiLocation, pNode);
+	const NiPoint3 kPos = GetActorHitWorldPos(apTarget, aiLocation, &pNode);
 	const NiPoint3 kDir = HitFXDirection(apAttacker, kPos);
 
-	if (abBlood) {
+	if (abBlood && apTarget->HasBlood()) {
 		PlayImpactParticle(apTarget->parentCell, pImpact, kPos, kDir);
 		AddActorBloodDecal(apTarget, pNode, pImpact, aiLocation, kPos, kDir);
 	}
@@ -364,8 +268,8 @@ static void SpawnActorHitFX(Actor* apTarget, Actor* apAttacker, TESObjectWEAP* a
 static TESObjectWEAP* ResolveHitWeapon(TESForm* apForm) {
 	if (apForm)
 		return static_cast<TESObjectWEAP*>(apForm);
-	TESObjectWEAP* pDefault = const_cast<TESObjectWEAP*>(pDefaultUnarmedWeapon.Get());
-	return (pDefault && reinterpret_cast<TESForm*>(pDefault)->IsWeapon()) ? pDefault : nullptr;
+
+	return const_cast<TESObjectWEAP*>(pDefaultUnarmedWeapon.Get());
 }
 
 }
@@ -373,111 +277,113 @@ static TESObjectWEAP* ResolveHitWeapon(TESForm* apForm) {
 bool Cmd_ApplyHitData_Execute(COMMAND_ARGS) {
 	*result = 0;
 
-	Actor* pAttacker = nullptr;
-	float fHealth = 10.0f, fFatigue = 0.0f, fLimb = 0.0f;
-	TESForm* pWeaponForm = nullptr;
-	int32_t iHitLocation = 0;
-	uint32_t uiFlags = 0, bFireOnHit = 1, bFireAlarm = 1, bFireBlood = 1, bFireSound = 1, bSkipClear = 0;
-
-	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &pAttacker, &fHealth, &fFatigue, &fLimb, &pWeaponForm,
-			&iHitLocation, &uiFlags, &bFireOnHit, &bFireAlarm, &bFireBlood, &bFireSound, &bSkipClear))
-		return true;
 	if (!thisObj)
 		return true;
-	if (!IsFinite3(fHealth, fFatigue, fLimb) || fHealth < 0.0f || fFatigue < 0.0f || fLimb < 0.0f)
-		return true;
-
-	if (iHitLocation < -1 || iHitLocation > 13)
-		iHitLocation = -1;
 
 	Actor* pTarget = static_cast<Actor*>(thisObj);
 	if (!pTarget->IsActor() || !pTarget->baseProcess)
 		return true;
+
+	TESActorBase* pTargetBase = static_cast<TESActorBase*>(pTarget->baseForm);
+	if (!pTargetBase)
+		return true;
+
+	Actor* pAttacker = nullptr;
+	float fHealth = 10.f, fFatigue = 0.f, fLimb = 0.f;
+	TESForm* pWeaponForm = nullptr;
+	BODY_PART_TYPE eHitLocation = BODY_PART_TYPE::NONE;
+	uint32_t uiFlags = 0, bFireOnHit = 1, bFireAlarm = 1, bFireBlood = 1, bFireSound = 1, bSkipClear = 0;
+
+	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &pAttacker, &fHealth, &fFatigue, &fLimb, &pWeaponForm,
+			&eHitLocation, &uiFlags, &bFireOnHit, &bFireAlarm, &bFireBlood, &bFireSound, &bSkipClear))
+		return true;
+
+	if (!IsFinite3(fHealth, fFatigue, fLimb) || fHealth < 0.f || fFatigue < 0.f || fLimb < 0.f)
+		return true;
+
+	if (eHitLocation < BODY_PART_TYPE::NONE || eHitLocation > BODY_PART_TYPE::BRAIN)
+		eHitLocation = BODY_PART_TYPE::NONE;
+
 	if (pAttacker && (!pAttacker->IsActor() || !pAttacker->baseProcess))
 		return true;
+
 	if (pWeaponForm && !pWeaponForm->IsWeapon())
 		return true;
 
 	TESObjectWEAP* pWeapon = ResolveHitWeapon(pWeaponForm);
 
-	ActorHitData kHit = {};
+	ActorHitData kHit;
 	kHit.source = pAttacker;
 	kHit.target = pTarget;
 	kHit.unk0C = pWeapon ? pWeapon->weaponSkill : kAVCode_Unarmed;
-	kHit.hitLocation = iHitLocation;
+	kHit.hitLocation = eHitLocation;
 	kHit.healthDmg = fHealth;
 	kHit.wpnBaseDmg = fHealth;
 	kHit.fatigueDmg = fFatigue;
 	kHit.limbDmg = fLimb;
 	kHit.weapon = pWeapon;
-	kHit.healthPerc = pWeapon ? 1.0f : 0.0f;
-	kHit.impactPos = FallbackHitPos(pTarget, iHitLocation);
+	kHit.healthPerc = pWeapon ? 1.f : 0.f;
+	kHit.impactPos = GetActorHitWorldPos(pTarget, eHitLocation, nullptr);
 	kHit.impactAngle = pAttacker
 		? HitFXDirection(pTarget, pAttacker->pos)
-		: NiPoint3(0.0f, 0.0f, 1.0f);
+		: NiPoint3(0.f, 0.f, 1.f);
 	kHit.flags = uiFlags;
-	kHit.dmgMult = 1.0f;
+	kHit.dmgMult = 1.f;
+
+	NiPointer<ActorHitData> spHitData(&kHit);
 
 	BaseProcess* pProc = pTarget->baseProcess;
 	bool bCopiedHitData = false;
-	__try {
-		pProc->CopyHitData(&kHit);
-		bCopiedHitData = true;
+	pProc->SetLastHitData(spHitData);
+	if (pAttacker)
+		pProc->SetLastAttackHitData(spHitData);
+	bCopiedHitData = true;
 
-		if (fHealth > 0.0f) {
-			void** pVtbl = *reinterpret_cast<void***>(pTarget);
-			ThisCall(reinterpret_cast<uintptr_t>(pVtbl[kActorDamageVtableSlot]),
-				pTarget, fHealth, 0.0f, pAttacker);
-		}
+	BGSBodyPartData* pBodyPartData = pTargetBase->GetBodyPartData();
 
-		if (fLimb > 0.0f && iHitLocation >= 0)
-			pTarget->DamageActorValue(BodyPartConditionAV(iHitLocation), -fLimb, pAttacker);
-
-		if (bFireOnHit) {
-			ExtraDataList* pExtra = &pTarget->extraDataList;
-			if (pAttacker)
-				CdeclCall(kAddrMergeScriptEvent, pAttacker, pExtra, 0x80);
-			if (pWeapon)
-				CdeclCall(kAddrMergeScriptEvent, pWeapon, pExtra, 0x100);
-		}
-
-		if (bFireAlarm && pAttacker &&
-				pAttacker == reinterpret_cast<Actor*>(PlayerCharacter::GetSingleton()))
-			ThisCall(kAddrSendAssaultAlarm, pTarget, pAttacker, 0, 0);
-
-		if (fFatigue > 0.0f)
-			pTarget->DamageActorValue(kAVCode_Fatigue, -fFatigue, pAttacker);
-
-		if (pWeaponForm && pWeapon && pWeapon->impactDataSet && (bFireBlood || bFireSound)) {
-			int32_t iBloodLoc = (iHitLocation >= 0) ? iHitLocation : 0;
-			int32_t iMaterial = GetActorBodyMaterial(pTarget);
-			if (iMaterial < 0)
-				iMaterial = ImpactSwap::eMT_Organic;
-			SpawnActorHitFX(pTarget, pAttacker, pWeapon, iBloodLoc, iMaterial, bFireBlood != 0, bFireSound != 0);
-		}
-
-		if (!bSkipClear) {
-			pProc->ResetHitData();
-			bCopiedHitData = false;
-		}
-
-		*result = 1;
+	if (fHealth > 0.f) {
+		pTarget->DoDamage(fHealth, 0.f, pAttacker);
 	}
-	__except (EXCEPTION_EXECUTE_HANDLER) {
-		if (bCopiedHitData) {
-			__try {
-				pProc->ResetHitData();
-			}
-			__except (EXCEPTION_EXECUTE_HANDLER) {
-			}
+
+	if (fLimb > 0.f && eHitLocation >= 0) {
+		BGSBodyPart* pBodyPart = pBodyPartData->GetBodyPart(eHitLocation);
+		if (pBodyPart)
+			pTarget->DamageActorValue(pBodyPart->GetActorValue(), -fLimb, pAttacker);
+
+	}
+	if (bFireOnHit) {
+		ExtraDataList* pExtra = &pTarget->extraDataList;
+		if (pAttacker)
+			Script::SetActionFlag(pAttacker, pExtra, 0x80);
+		if (pWeapon)
+			Script::SetActionFlag(pWeapon, pExtra, 0x100);
+	}
+
+	if (bFireAlarm && pAttacker == PlayerCharacter::GetSingleton())
+		pTarget->AttackAlarm(pAttacker, false);
+
+	if (fFatigue > 0.f)
+		pTarget->DamageActorValue(kAVCode_Fatigue, -fFatigue, pAttacker);
+
+	if (pWeaponForm && pWeapon && pWeapon->impactDataSet && (bFireBlood || bFireSound)) {
+		BODY_PART_TYPE eBloodLoc = (eHitLocation >= 0) ? eHitLocation : BODY_PART_TYPE::TORSO;
+		int32_t iMaterial = GetActorBodyMaterial(pTarget);
+		if (iMaterial >= 0) {
+			SpawnActorHitFX(pTarget, pAttacker, pWeapon, eBloodLoc, iMaterial, bFireBlood != 0, bFireSound != 0);
 		}
 	}
+
+	if (!bSkipClear) {
+		pProc->ClearLastHitData();
+		pProc->ClearLastAttackHitData();
+		bCopiedHitData = false;
+	}
+
+	*result = 1;
 	return true;
 }
 
 namespace {
-
-static const float kGameToHavok = 0.142875f;
 
 struct __declspec(align(16)) PickRayData {
 	float		fFrom[4];
@@ -500,6 +406,10 @@ struct __declspec(align(16)) PickRayData {
 	void*		pAllCollector;
 	uint8_t		ucFailed;
 	uint8_t		padAD[3];
+
+	void CalcHitPoint(NiPoint3& arHitPoint) const {
+		ThisCall(0x5DBE60, this, &arHitPoint);
+	}
 };
 static_assert(sizeof(PickRayData) == 0xB0);
 static_assert(offsetof(PickRayData, fHitFraction) == 0x40);
@@ -509,7 +419,6 @@ static_assert(sizeof(hkCdBody) == 0x10);
 static_assert(offsetof(hkpWorldObject, cdBody) == 0x10);
 static_assert(offsetof(hkpWorldObject, collisionType) == 0x28);
 static_assert(offsetof(hkpShape, shape) == 0x08);
-static_assert(offsetof(bhkShape, unk10) == 0x10);
 static_assert(sizeof(bhkRefObject) == 0x0C);
 static_assert(offsetof(bhkRefObject, refObject) == 0x08);
 static_assert(sizeof(bhkNiCollisionObject) == 0x14);
@@ -520,44 +429,32 @@ struct CollisionFilter {
 };
 static_assert(sizeof(CollisionFilter) == 4);
 
-static int32_t CollidableRootMaterial(const void* apCollidable, const NiPoint3* apPos) {
-	return ConvertHavokMaterial(CdeclCall<uint32_t>(
-		kAddrGetMaterialFromCollidable, apCollidable, apPos));
-}
-
-static bhkShape* ShapeGetBhk(const hkpShape* apHkpShape) {
-	return apHkpShape ? apHkpShape->shape : nullptr;
-}
-
-static int32_t BhkShapeMaterial(const bhkShape* apBhkShape) {
-	return apBhkShape ? ConvertHavokMaterial(apBhkShape->unk10) : -1;
+static int32_t CollidableRootMaterial(const void* apCollidable, const NiPoint3& arPos) {
+	return MaterialTypeToImpactData(CdeclCall<uint32_t>(kAddrGetMaterialFromCollidable, apCollidable, &arPos));
 }
 
 static int32_t BhkShapeSubMaterial(bhkShape* apBhkShape, uint32_t auiShapeKey) {
-	return ConvertHavokMaterial(ThisCall<uint32_t>(
-		kAddrGetSubshapeMaterial, apBhkShape, auiShapeKey));
+	return MaterialTypeToImpactData(apBhkShape->GetSubshapeMaterial(auiShapeKey));
 }
 
 static void* HkpShapeContainer(void* apShape) {
 	if (!apShape)
 		return nullptr;
 	void** pVtbl = *reinterpret_cast<void***>(apShape);
-	return ThisCall<void*>(reinterpret_cast<uintptr_t>(
-		pVtbl[kShapeGetContainerVtableSlot]), apShape);
+	return ThisCall<void*>(reinterpret_cast<uintptr_t>(pVtbl[kShapeGetContainerVtableSlot]), apShape);
 }
 
 static void* HkpContainerChild(void* apContainer, uint32_t auiKey, void* apBuffer) {
 	if (!apContainer)
 		return nullptr;
 	void** pVtbl = *reinterpret_cast<void***>(apContainer);
-	return ThisCall<void*>(reinterpret_cast<uintptr_t>(
-		pVtbl[kShapeGetChildVtableSlot]), apContainer, auiKey, apBuffer);
+	return ThisCall<void*>(reinterpret_cast<uintptr_t>(pVtbl[kShapeGetChildVtableSlot]), apContainer, auiKey, apBuffer);
 }
 
 static int32_t ChildShapeMaterial(void* apContainer, uint32_t auiKey, void* apBuffer) {
 	hkpShape* pChildShape = static_cast<hkpShape*>(HkpContainerChild(apContainer, auiKey, apBuffer));
-	bhkShape* pChildBhk = ShapeGetBhk(pChildShape);
-	return pChildBhk ? BhkShapeMaterial(pChildBhk) : -1;
+	bhkShape* pChildBhk = bhkShape::Getbhk(pChildShape);
+	return pChildBhk ? MaterialTypeToImpactData(pChildBhk->GetMaterial()) : -1;
 }
 
 struct MaterialCandidates {
@@ -574,24 +471,21 @@ static void NoteMaterialCandidate(int32_t aiMat, int32_t& arBest, int32_t& arFal
 		arFallback = aiMat;
 }
 
-static void ProbeShapeKey(void* apContainer, bhkShape* apBhkShape, uint32_t auiKey,
-                          void* apChildBuffer, MaterialCandidates& arCandidates) {
+static void ProbeShapeKey(void* apContainer, bhkShape* apBhkShape, uint32_t auiKey, void* apChildBuffer, MaterialCandidates& arCandidates) {
 	if (auiKey == 0xFFFFFFFF)
 		return;
+
 	if (apContainer) {
-		NoteMaterialCandidate(ChildShapeMaterial(apContainer, auiKey, apChildBuffer),
-			arCandidates.iChildBest, arCandidates.iChildFallback);
+		NoteMaterialCandidate(ChildShapeMaterial(apContainer, auiKey, apChildBuffer), arCandidates.iChildBest, arCandidates.iChildFallback);
 		if (arCandidates.iChildBest > 0)
 			return;
 	}
-	NoteMaterialCandidate(BhkShapeSubMaterial(apBhkShape, auiKey),
-		arCandidates.iSubBest, arCandidates.iSubFallback);
+
+	NoteMaterialCandidate(BhkShapeSubMaterial(apBhkShape, auiKey), arCandidates.iSubBest, arCandidates.iSubFallback);
 }
 
 static uint32_t PlayerCollisionGroup() {
 	PlayerCharacter* pPlayer = PlayerCharacter::GetSingleton();
-	if (!pPlayer)
-		return 0;
 	CollisionFilter kFilter;
 	ThisCall(kAddrGetCollisionFilter, pPlayer, &kFilter);
 	return kFilter.uiFilter & 0xFFFF0000;
@@ -609,9 +503,9 @@ static int32_t ChooseMaterial(int32_t aiHitMat, const MaterialCandidates& arCand
 static int32_t RaycastSubshapeMaterial(float afCamX, float afCamY, float afCamZ,
                                        float afHitX, float afHitY, float afHitZ, int32_t aiLayer) {
 	PickRayData kPick = {};
-	kPick.fFrom[0] = afCamX * kGameToHavok;
-	kPick.fFrom[1] = afCamY * kGameToHavok;
-	kPick.fFrom[2] = afCamZ * kGameToHavok;
+	kPick.fFrom[0] = afCamX * fNI2HK;
+	kPick.fFrom[1] = afCamY * fNI2HK;
+	kPick.fFrom[2] = afCamZ * fNI2HK;
 	const double fEndX64 = afCamX + (static_cast<double>(afHitX) - afCamX) * 1.05;
 	const double fEndY64 = afCamY + (static_cast<double>(afHitY) - afCamY) * 1.05;
 	const double fEndZ64 = afCamZ + (static_cast<double>(afHitZ) - afCamZ) * 1.05;
@@ -623,157 +517,140 @@ static int32_t RaycastSubshapeMaterial(float afCamX, float afCamY, float afCamZ,
 	const float fEndX = static_cast<float>(fEndX64);
 	const float fEndY = static_cast<float>(fEndY64);
 	const float fEndZ = static_cast<float>(fEndZ64);
-	kPick.fTo[0] = fEndX * kGameToHavok;
-	kPick.fTo[1] = fEndY * kGameToHavok;
-	kPick.fTo[2] = fEndZ * kGameToHavok;
+	kPick.fTo[0] = fEndX * fNI2HK;
+	kPick.fTo[1] = fEndY * fNI2HK;
+	kPick.fTo[2] = fEndZ * fNI2HK;
 	if (!IsFinite3(kPick.fFrom[0], kPick.fFrom[1], kPick.fFrom[2]) ||
 			!IsFinite3(kPick.fTo[0], kPick.fTo[1], kPick.fTo[2]))
 		return -1;
-	kPick.fHitFraction = 1.0f;
+	kPick.fHitFraction = 1.f;
 	kPick.uiExtraInfo = 0xFFFFFFFF;
 	kPick.uiShapeKeys[0] = 0xFFFFFFFF;
 
-	__try {
-		kPick.uiFilterInfo = static_cast<uint32_t>(aiLayer) | PlayerCollisionGroup();
+	kPick.uiFilterInfo = static_cast<uint32_t>(aiLayer) | PlayerCollisionGroup();
 
-		TES* pTES = TES::GetSingleton();
-		if (!pTES)
-			return -1;
-		if (!ThisCall<void*>(kAddrPick, pTES, &kPick, 1))
-			return -1;
-
-		void* pRoot = kPick.pRootCollidable;
-		if (!pRoot)
-			return -1;
-
-		float fFrac = kPick.fHitFraction;
-		if (fFrac < 0.0f || fFrac > 1.0f)
-			fFrac = 1.0f;
-
-		const double fPickX = afCamX + (fEndX64 - afCamX) * fFrac;
-		const double fPickY = afCamY + (fEndY64 - afCamY) * fFrac;
-		const double fPickZ = afCamZ + (fEndZ64 - afCamZ) * fFrac;
-		if (!std::isfinite(fPickX) || !std::isfinite(fPickY) || !std::isfinite(fPickZ) ||
-				std::fabs(fPickX) > std::numeric_limits<float>::max() ||
-				std::fabs(fPickY) > std::numeric_limits<float>::max() ||
-				std::fabs(fPickZ) > std::numeric_limits<float>::max())
-			return -1;
-		NiPoint3 kHitPos(
-			static_cast<float>(fPickX),
-			static_cast<float>(fPickY),
-			static_cast<float>(fPickZ));
-		ThisCall(kAddrCalcPickHitPoint, &kPick, &kHitPos);
-		if (!IsFinite3(kHitPos.x, kHitPos.y, kHitPos.z))
-			return -1;
-
-		const int32_t iHitMat = CollidableRootMaterial(pRoot, &kHitPos);
-
-		hkpShape* pRootShape = *reinterpret_cast<hkpShape**>(pRoot);
-		bhkShape* pBhkShape = ShapeGetBhk(pRootShape);
-		MaterialCandidates kCandidates;
-		if (pBhkShape) {
-			void* pContainer = HkpShapeContainer(pRootShape);
-			__declspec(align(16)) uint8_t kChildBuffer[512];
-			void* pChildBuffer = nullptr;
-			if (pContainer) {
-				std::memset(kChildBuffer, 0, sizeof(kChildBuffer));
-				pChildBuffer = kChildBuffer;
-			}
-			for (int32_t i = 1; i <= 7; ++i) {
-				ProbeShapeKey(pContainer, pBhkShape, kPick.uiShapeKeys[i], pChildBuffer, kCandidates);
-				if (kCandidates.iChildBest > 0)
-					break;
-			}
-			if (kCandidates.iChildBest <= 0)
-				ProbeShapeKey(pContainer, pBhkShape, kPick.uiShapeKeys[0], pChildBuffer, kCandidates);
-		}
-
-		int32_t iChosen = ChooseMaterial(iHitMat, kCandidates);
-		if (iChosen < 0) {
-			NiPoint3 kScriptHitPos(afHitX, afHitY, afHitZ);
-			const int32_t iScriptMat = CollidableRootMaterial(pRoot, &kScriptHitPos);
-			if (iScriptMat >= 0)
-				iChosen = iScriptMat;
-		}
-		return iChosen;
-	}
-	__except (EXCEPTION_EXECUTE_HANDLER) {
+	TES* pTES = TES::GetSingleton();
+	if (!pTES)
 		return -1;
-	}
-}
 
-struct HavokRecData {
-	void*		pWorld = nullptr;
-	uint8_t		ucRecurse = 0;
-	uint8_t		pad05[3] = {};
-	uint32_t	uiAction = 0;
-	uint32_t	uiData0 = 0;
-	uint32_t	uiData1 = 0;
-	int32_t		iOutMaterial = -1;
-	uint32_t	uiData3 = 0;
-};
-static_assert(sizeof(HavokRecData) == 0x1C);
-static_assert(offsetof(HavokRecData, uiAction) == 0x08);
-static_assert(offsetof(HavokRecData, iOutMaterial) == 0x14);
+	if (!ThisCall<NiAVObject*>(kAddrPick, pTES, &kPick, 1))
+		return -1;
+
+	void* pRoot = kPick.pRootCollidable;
+	if (!pRoot)
+		return -1;
+
+	float fFrac = kPick.fHitFraction;
+	if (fFrac < 0.f || fFrac > 1.f)
+		fFrac = 1.f;
+
+	const double fPickX = afCamX + (fEndX64 - afCamX) * fFrac;
+	const double fPickY = afCamY + (fEndY64 - afCamY) * fFrac;
+	const double fPickZ = afCamZ + (fEndZ64 - afCamZ) * fFrac;
+	if (!std::isfinite(fPickX) || !std::isfinite(fPickY) || !std::isfinite(fPickZ) ||
+		std::fabs(fPickX) > std::numeric_limits<float>::max() ||
+		std::fabs(fPickY) > std::numeric_limits<float>::max() ||
+		std::fabs(fPickZ) > std::numeric_limits<float>::max())
+		return -1;
+	NiPoint3 kHitPos(
+		static_cast<float>(fPickX),
+		static_cast<float>(fPickY),
+		static_cast<float>(fPickZ));
+	kPick.CalcHitPoint(kHitPos);
+	if (!IsFinite3(kHitPos.x, kHitPos.y, kHitPos.z))
+		return -1;
+
+	const int32_t iHitMat = CollidableRootMaterial(pRoot, kHitPos);
+
+	hkpShape* pRootShape = *reinterpret_cast<hkpShape**>(pRoot);
+	bhkShape* pBhkShape = bhkShape::Getbhk(pRootShape);
+	MaterialCandidates kCandidates;
+	if (pBhkShape) {
+		void* pContainer = HkpShapeContainer(pRootShape);
+		__declspec(align(16)) uint8_t kChildBuffer[512];
+		void* pChildBuffer = nullptr;
+		if (pContainer) {
+			std::memset(kChildBuffer, 0, sizeof(kChildBuffer));
+			pChildBuffer = kChildBuffer;
+		}
+		for (int32_t i = 1; i <= 7; ++i) {
+			ProbeShapeKey(pContainer, pBhkShape, kPick.uiShapeKeys[i], pChildBuffer, kCandidates);
+			if (kCandidates.iChildBest > 0)
+				break;
+		}
+		if (kCandidates.iChildBest <= 0)
+			ProbeShapeKey(pContainer, pBhkShape, kPick.uiShapeKeys[0], pChildBuffer, kCandidates);
+	}
+
+	int32_t iChosen = ChooseMaterial(iHitMat, kCandidates);
+	if (iChosen < 0) {
+		NiPoint3 kScriptHitPos(afHitX, afHitY, afHitZ);
+		const int32_t iScriptMat = CollidableRootMaterial(pRoot, kScriptHitPos);
+		if (iScriptMat >= 0)
+			iChosen = iScriptMat;
+	}
+	return iChosen;
+}
 
 static int32_t CollisionObjectMaterial(void* apCollisionObject) {
 	if (!apCollisionObject)
 		return -1;
+
 	bhkNiCollisionObject* pCollision = static_cast<bhkNiCollisionObject*>(apCollisionObject);
 	if (!pCollision->worldObj || !pCollision->worldObj->refObject)
 		return -1;
+
 	hkpWorldObject* pBody = static_cast<hkpWorldObject*>(pCollision->worldObj->refObject);
 	hkpShape* pShape = static_cast<hkpShape*>(pBody->cdBody.shape);
 	if (!pShape || !pShape->shape)
 		return -1;
-	return ConvertHavokMaterial(pShape->shape->unk10); // unk10 = havok material
+
+	return MaterialTypeToImpactData(pShape->shape->GetMaterial());
 }
 
-static void __cdecl FirstMaterialCallback(void* apCollisionObject, HavokRecData* apData) {
-	if (!apData || apData->iOutMaterial >= 0)
-		return;
+static void __cdecl FirstMaterialCallback(bhkNiCollisionObject* apCollisionObject, bhkWorld::ObjectRecData& arData) {
 	const int32_t iMat = CollisionObjectMaterial(apCollisionObject);
-	if (iMat >= 0)
-		apData->iOutMaterial = iMat;
+	if (iMat >= 0) {
+		arData.uData[0].i = iMat;
+		arData.bRecurse = false;
+	}
 }
 
 static int32_t GetObjectImpactMaterial(TESObjectREFR* apRef) {
 	if (apRef->IsActor())
-		return GetActorBodyMaterial(apRef);
+		return GetActorBodyMaterial(static_cast<Actor*>(apRef));
 
 	NiAVObject* pRoot = apRef->Get3D();
 	if (!pRoot)
 		return -1;
-	HavokRecData kData;
-	kData.ucRecurse = 1;
-	kData.uiAction = 8;
-	__try {
-		CdeclCall(kAddrVisitHavokObjects, pRoot, &kData, FirstMaterialCallback);
-		if (kData.iOutMaterial < 0)
-			kData.iOutMaterial = CollisionObjectMaterial(pRoot->m_spCollisionObject);
-	}
-	__except (EXCEPTION_EXECUTE_HANDLER) {
-		return -1;
-	}
-	return kData.iOutMaterial;
+	bhkWorld::ObjectRecData kData;
+	kData.bRecurse = true;
+	kData.eAction = 0;
+	kData.uData[0].i = -1;
+	bhkWorld::DoObjectRec(pRoot, kData, FirstMaterialCallback);
+	if (kData.uData[0].i < 0)
+		kData.uData[0].i = CollisionObjectMaterial(pRoot->m_spCollisionObject);
+	return kData.uData[0].i;
 }
 
 }
 
 bool Cmd_GetObjectMaterial_Execute(COMMAND_ARGS) {
 	*result = -1;
-	float fCamX = 3.0e38f, fCamY = 0.0f, fCamZ = 0.0f, fHitX = 0.0f, fHitY = 0.0f, fHitZ = 0.0f;
+
+	if (!thisObj)
+		return true;
+
+	float fCamX = 3.0e38f, fCamY = 0.f, fCamZ = 0.f, fHitX = 0.f, fHitY = 0.f, fHitZ = 0.f;
 	int32_t iLayer = 6;
 	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &fCamX, &fCamY, &fCamZ, &fHitX, &fHitY, &fHitZ, &iLayer))
-		return true;
-	if (!thisObj)
 		return true;
 
 	if (!std::isfinite(fCamX))
 		return true;
+
 	if (fCamX < 1.0e38f) {
-		if (!IsFinite3(fCamX, fCamY, fCamZ) || !IsFinite3(fHitX, fHitY, fHitZ) ||
-				iLayer < 0 || iLayer > 0x7F)
+		if (!IsFinite3(fCamX, fCamY, fCamZ) || !IsFinite3(fHitX, fHitY, fHitZ) || iLayer < 0 || iLayer > 0x7F)
 			return true;
 		*result = RaycastSubshapeMaterial(fCamX, fCamY, fCamZ, fHitX, fHitY, fHitZ, iLayer);
 	} else {
@@ -785,6 +662,9 @@ bool Cmd_GetObjectMaterial_Execute(COMMAND_ARGS) {
 bool Cmd_ApplyObjectImpact_Execute(COMMAND_ARGS) {
 	*result = -1;
 
+	if (!thisObj)
+		return true;
+
 	int32_t iMaterial = -1;
 	TESForm* pWeaponForm = nullptr;
 	uint32_t bSound = 1, bParticle = 1;
@@ -792,43 +672,39 @@ bool Cmd_ApplyObjectImpact_Execute(COMMAND_ARGS) {
 
 	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &iMaterial, &pWeaponForm, &bSound, &bParticle, &fPosX, &fPosY, &fPosZ))
 		return true;
-	if (!thisObj)
-		return true;
+
 	if (pWeaponForm && !pWeaponForm->IsWeapon())
 		return true;
+
 	if (!IsFinite3(fPosX, fPosY, fPosZ))
 		return true;
 
-	__try {
-		TESObjectWEAP* pWeapon = ResolveHitWeapon(pWeaponForm);
-		if (!pWeapon || !pWeapon->impactDataSet)
-			return true;
+	TESObjectWEAP* pWeapon = ResolveHitWeapon(pWeaponForm);
+	if (!pWeapon || !pWeapon->impactDataSet)
+		return true;
 
-		if (iMaterial < 0)
-			iMaterial = GetObjectImpactMaterial(thisObj);
-		if (iMaterial < 0 || iMaterial >= ImpactSwap::eMT_Max)
-			return true;
+	if (iMaterial < 0)
+		iMaterial = GetObjectImpactMaterial(thisObj);
+	if (iMaterial < 0 || iMaterial >= ImpactSwap::eMT_Max)
+		return true;
 
-		BGSImpactData* pImpact = pWeapon->impactDataSet->impactDatas[iMaterial];
-		if (!pImpact)
-			return true;
+	BGSImpactData* pImpact = pWeapon->impactDataSet->impactDatas[iMaterial];
+	if (!pImpact)
+		return true;
 
-		NiPoint3 kPos = (fPosX > 1.0e38f || fPosY > 1.0e38f || fPosZ > 1.0e38f)
-			? thisObj->pos
-			: NiPoint3(fPosX, fPosY, fPosZ);
-		const NiPoint3 kDir = HitFXDirection(
-			reinterpret_cast<Actor*>(PlayerCharacter::GetSingleton()), kPos);
+	NiPoint3 kPos = (fPosX > 1.0e38f || fPosY > 1.0e38f || fPosZ > 1.0e38f)
+		? thisObj->pos
+		: NiPoint3(fPosX, fPosY, fPosZ);
+	const NiPoint3 kDir = HitFXDirection(
+		reinterpret_cast<Actor*>(PlayerCharacter::GetSingleton()), kPos);
 
-		if (bParticle)
-			PlayImpactParticle(thisObj->parentCell, pImpact, kPos, kDir);
-		if (bSound) {
-			PlayImpactSound(pImpact->sound1, kPos, nullptr);
-			PlayImpactSound(pImpact->sound2, kPos, nullptr);
-		}
-		*result = iMaterial;
+	if (bParticle)
+		PlayImpactParticle(thisObj->parentCell, pImpact, kPos, kDir);
+	if (bSound) {
+		PlayImpactSound(pImpact->sound1, kPos, nullptr);
+		PlayImpactSound(pImpact->sound2, kPos, nullptr);
 	}
-	__except (EXCEPTION_EXECUTE_HANDLER) {
-	}
+	*result = iMaterial;
 	return true;
 }
 
@@ -836,12 +712,15 @@ bool Cmd_InterruptWeaponAnim_Execute(COMMAND_ARGS) {
 	*result = -2;
 	if (!thisObj)
 		return true;
+
 	Actor* pActor = static_cast<Actor*>(thisObj);
 	if (!pActor->IsActor() || !pActor->baseProcess)
 		return true;
-	if (pActor->baseProcess->processLevel != 0)
-		return true;
+
 	HighProcess* pProc = static_cast<HighProcess*>(pActor->baseProcess);
+
+	if (pProc->processLevel != 0)
+		return true;
 
 	Animation* pAnimation = pProc->animData;
 	if (!pAnimation)
@@ -854,24 +733,14 @@ bool Cmd_InterruptWeaponAnim_Execute(COMMAND_ARGS) {
 		return true;
 	}
 
-	__try {
-		for (int32_t iSeq = 4; iSeq <= 6; ++iSeq) {
-			if (BSAnimGroupSequence* pSequence = pAnimation->animSequence[iSeq])
-				if (pAnimation->unk0D8)
-					pAnimation->unk0D8->DeactivateSequence(pSequence, 0.0f);
-			ThisCall(kAddrClearAnimGroup, pAnimation, iSeq, 0.0f);
-		}
-		ThisCall(kAddrSetAnimActionAndSequence, pActor, -1, nullptr);
-		*result = sOldAction;
-	}
-	__except (EXCEPTION_EXECUTE_HANDLER) {
-	}
+	pAnimation->ClearGroup(ANIM_GROUP_SECTION::WEAPON, 0.f);
+	pActor->SetAnimAction(ANIMATION_ACTION::NONE, nullptr);
+	*result = sOldAction;
 	return true;
 }
 
 namespace {
 
-static const float kHavokToGame = 6.99903965f;
 static_assert(sizeof(hkpWorldObject) == 0x8C);
 static_assert(sizeof(hkpMotion) == 0x140);
 static_assert(offsetof(hkpMotion, linVelocity) == 0xD0);
@@ -881,17 +750,15 @@ static_assert(sizeof(bhkWorldObject) == 0x14);
 static_assert(offsetof(bhkWorldObject, refObject) == 0x08);
 static_assert(sizeof(bhkRigidBody) == 0x1C);
 
-static float* GetRigidBodyCenterOfMass(bhkWorldObject* apWorldObject, float* apOut) {
+static float* __fastcall GetRigidBodyCenterOfMass(bhkWorldObject* apWorldObject, float* apOut) {
 	void** pVtbl = *reinterpret_cast<void***>(apWorldObject);
-	return ThisCall<float*>(reinterpret_cast<uintptr_t>(
-		pVtbl[kRigidBodyCenterVtableSlot]), apWorldObject, apOut);
+	return ThisCall<float*>(reinterpret_cast<uintptr_t>(pVtbl[kRigidBodyCenterVtableSlot]), apWorldObject, apOut);
 }
 
-static void PushNodeBodies(NiAVObject* apObject, uint32_t auiDepth,
-                           float afOriginX, float afOriginY, float afOriginZ,
-                           float afForce, uint32_t& arCount) {
+static void __fastcall PushNodeBodies(NiAVObject* apObject, uint32_t auiDepth, const NiPoint3& arOrigin, float afForce, uint32_t& arCount) {
 	if (!apObject || auiDepth > 64)
 		return;
+
 	NiNode* pNode = apObject->IsNode();
 	if (!pNode)
 		return;
@@ -903,14 +770,14 @@ static void PushNodeBodies(NiAVObject* apObject, uint32_t auiDepth,
 		__declspec(align(16)) float kBodyPos[4];
 		float* pPos = GetRigidBodyCenterOfMass(pWorldObj, kBodyPos);
 		if (pPos && IsFinite3(pPos[0], pPos[1], pPos[2])) {
-			double fDX = static_cast<double>(pPos[0]) * kHavokToGame - afOriginX;
-			double fDY = static_cast<double>(pPos[1]) * kHavokToGame - afOriginY;
-			double fDZ = static_cast<double>(pPos[2]) * kHavokToGame - afOriginZ;
+			double fDX = static_cast<double>(pPos[0]) * fHK2NI - arOrigin.x;
+			double fDY = static_cast<double>(pPos[1]) * fHK2NI - arOrigin.y;
+			double fDZ = static_cast<double>(pPos[2]) * fHK2NI - arOrigin.z;
 			if (fDZ > 0.0)
 				fDZ = 0.0;
 			const double fLen = std::sqrt(fDX * fDX + fDY * fDY + fDZ * fDZ);
 			if (std::isfinite(fLen) && fLen > 0.0001) {
-				const double fScale = static_cast<double>(afForce) * kGameToHavok / fLen;
+				const double fScale = static_cast<double>(afForce) * fNI2HK / fLen;
 				NiPoint4 kVelocity = pRigid->motion.linVelocity;
 				const float fNewX = static_cast<float>(kVelocity.x + fDX * fScale);
 				const float fNewY = static_cast<float>(kVelocity.y + fDY * fScale);
@@ -930,36 +797,38 @@ static void PushNodeBodies(NiAVObject* apObject, uint32_t auiDepth,
 	const uint32_t uiChildCount = pNode->GetArrayCount();
 	if (uiChildCount > 1024)
 		return;
+
 	for (uint32_t i = 0; i < uiChildCount; ++i)
 		if (NiAVObject* pChild = pNode->GetAt(i))
-			PushNodeBodies(pChild, auiDepth + 1, afOriginX, afOriginY, afOriginZ, afForce, arCount);
+			PushNodeBodies(pChild, auiDepth + 1, arOrigin, afForce, arCount);
 }
 
 }
 
 bool Cmd_ApplyRagdollForce_Execute(COMMAND_ARGS) {
 	*result = 0;
-	float fForce = 0.0f, fOriginX = 0.0f, fOriginY = 0.0f, fOriginZ = 0.0f;
-	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &fForce, &fOriginX, &fOriginY, &fOriginZ))
+	float fForce = 0.f;
+	NiPoint3 kOrigin;
+	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &fForce, &kOrigin.x, &kOrigin.y, &kOrigin.z))
 		return true;
+
 	if (!thisObj)
 		return true;
-	if (!std::isfinite(fForce) || !IsFinite3(fOriginX, fOriginY, fOriginZ) || fForce == 0.0f)
+
+	if (!std::isfinite(fForce) || !IsFinite3(kOrigin.x, kOrigin.y, kOrigin.z) || fForce == 0.f)
 		return true;
+
 	Actor* pActor = static_cast<Actor*>(thisObj);
 	if (!pActor->IsActor() || !pActor->baseProcess)
 		return true;
+
 	// Get3DSimple, not Get3D. The player override returns the 1st person arms in 1st person.
 	NiAVObject* pRoot = pActor->Get3DSimple();
 	if (!pRoot)
 		return true;
+
 	uint32_t uiCount = 0;
-	__try {
-		PushNodeBodies(pRoot, 0, fOriginX, fOriginY, fOriginZ, fForce, uiCount);
-	}
-	__except (EXCEPTION_EXECUTE_HANDLER) {
-		return true;
-	}
+	PushNodeBodies(pRoot, 0, kOrigin, fForce, uiCount);
 	*result = uiCount;
 	return true;
 }
@@ -975,20 +844,19 @@ bool Cmd_Set3rdPersonOverlay_Execute(COMMAND_ARGS) {
 }
 
 bool Cmd_Set3rdPersonOverlayCullParts_Execute(COMMAND_ARGS) {
-	*result = PlayerBodyOverlay::GetCullPartBits();
 	int32_t iMode = 0;
 	int32_t kParts[16];
 	for (int32_t i = 0; i < 16; ++i)
 		kParts[i] = -1;
-	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &iMode,
-			&kParts[0], &kParts[1], &kParts[2], &kParts[3],
-			&kParts[4], &kParts[5], &kParts[6], &kParts[7],
-			&kParts[8], &kParts[9], &kParts[10], &kParts[11],
-			&kParts[12], &kParts[13], &kParts[14], &kParts[15]))
-		return true;
+	if (ExtractArgsEx(EXTRACT_ARGS_EX, &iMode,
+		&kParts[0], &kParts[1], &kParts[2], &kParts[3],
+		&kParts[4], &kParts[5], &kParts[6], &kParts[7],
+		&kParts[8], &kParts[9], &kParts[10], &kParts[11],
+		&kParts[12], &kParts[13], &kParts[14], &kParts[15])) {
 
-	const uint32_t uiBits = (iMode >= 1 && iMode <= 2) ? PlayerBodyOverlay::BuildPartBits(kParts, 16) : 0;
-	PlayerBodyOverlay::SetCullParts(iMode, uiBits);
+		const uint32_t uiBits = (iMode >= 1 && iMode <= 2) ? PlayerBodyOverlay::BuildPartBits(kParts, ARRAYSIZE(kParts)) : 0;
+		PlayerBodyOverlay::SetCullParts(iMode, uiBits);
+	}
 	*result = PlayerBodyOverlay::GetCullPartBits();
 	return true;
 }

--- a/JG/functions/fn_hit.h
+++ b/JG/functions/fn_hit.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "fn_common.h"
+
+DEFINE_COMMAND_PLUGIN(ApplyHitData, , true, kParams_ApplyHitData);
+DEFINE_COMMAND_PLUGIN(GetObjectMaterial, , true, kParams_GetObjectMaterial);
+DEFINE_COMMAND_PLUGIN(ApplyObjectImpact, , true, kParams_ApplyObjectImpact);
+DEFINE_COMMAND_PLUGIN(InterruptWeaponAnim, , true, nullptr);
+DEFINE_COMMAND_PLUGIN(ApplyRagdollForce, , true, kParams_FourFloats);
+DEFINE_COMMAND_PLUGIN(Set3rdPersonOverlay, , false, kParams_OneInt_OneOptionalInt);
+DEFINE_COMMAND_PLUGIN(Set3rdPersonOverlayCullParts, , false, kParams_Set3rdPersonOverlayCullParts);

--- a/JG/functions/fn_math.cpp
+++ b/JG/functions/fn_math.cpp
@@ -250,7 +250,7 @@ bool Cmd_Get3DDistanceFromHitToNiNode_Execute(COMMAND_ARGS) {
 	char cObjectName[MAX_PATH];
 	if (ExtractArgsEx(EXTRACT_ARGS_EX, &cObjectName) && pActor->IsMobileObject() && pActor->baseProcess) {
 		const NiAVObject* pObject = thisObj->GetNiBlock(cObjectName);
-		const ActorHitData* pHitData = pActor->baseProcess->GetHitData();
+		const ActorHitData* pHitData = pActor->baseProcess->GetLastHitData();
 		if (!pHitData || !pObject) 
 			return true;
 		

--- a/JG/internal/JG/JohnnyCommands.cpp
+++ b/JG/internal/JG/JohnnyCommands.cpp
@@ -9,6 +9,7 @@
 #include "functions/fn_form.h"
 #include "functions/fn_gamebryo.h"
 #include "functions/fn_gameplay.h"
+#include "functions/fn_hit.h"
 #include "functions/fn_math.h"
 #include "functions/fn_mediaset.h"
 #include "functions/fn_region.h"
@@ -434,6 +435,13 @@ namespace JohnnyCommands {
 		REG_CMD(GetNiLightValue);
 		REG_CMD(SetNiLightColor);
 		REG_CMD(GetNiLightColor);
+		REG_CMD(ApplyHitData);
+		REG_CMD(GetObjectMaterial);
+		REG_CMD(ApplyObjectImpact);
+		REG_CMD(InterruptWeaponAnim);
+		REG_CMD(ApplyRagdollForce);
+		REG_CMD(Set3rdPersonOverlay);
+		REG_CMD(Set3rdPersonOverlayCullParts);
 	}
 
 }

--- a/JG/internal/JG/JohnnyMessageHandler.cpp
+++ b/JG/internal/JG/JohnnyMessageHandler.cpp
@@ -19,6 +19,7 @@
 #include "LandRemapping.hpp"
 #include "MediaLocationControllerTweaks.hpp"
 #include "NPCAccuracy.hpp"
+#include "PlayerBodyOverlay.hpp"
 #include "RSMBarberHook.hpp"
 #include "TaskQueue.hpp"
 
@@ -78,6 +79,7 @@ static void MainGameLoop() {
 
 static void __fastcall GameReset(uint32_t aeType) {
 	JohnnyExtraDataArray::GetInstance().ResetScriptData();
+	PlayerBodyOverlay::Reset();
 
 	if (aeType == NVSEMessagingInterface::kMessage_NewGame)
 		CameraOverlay::ReInit();
@@ -141,6 +143,9 @@ void JohnnyMessageHandler::Game(NVSEMessagingInterface::Message* apMessage) {
 				break;
 			[[unlikely]] case NVSEMessagingInterface::kMessage_PostLoadGame:
 				PostLoadGame();
+				break;
+			[[unlikely]] case NVSEMessagingInterface::kMessage_ExitToMainMenu:
+				PlayerBodyOverlay::Reset();
 				break;
 			default:
 				break;

--- a/JG/internal/JG/PlayerBodyOverlay.cpp
+++ b/JG/internal/JG/PlayerBodyOverlay.cpp
@@ -1,0 +1,1036 @@
+#include "PlayerBodyOverlay.hpp"
+
+#include "Bethesda/BSExtraData.hpp"
+#include "Bethesda/TESMain.hpp"
+#include "netimmerse.h"
+#include "utility.h"
+#include "shared/SafeWrite/SafeWrite.hpp"
+
+#include <GameObjects.h>
+#include <decoding.h>
+
+#include <Windows.h>
+#include <cstddef>
+#include <cmath>
+#include <cstring>
+
+namespace PlayerBodyOverlay {
+namespace {
+
+	constexpr uint32_t kNiFlagHidden		= 0x00000001;
+	constexpr uint32_t kNiFlagNotVisible	= 0x00100000;
+	constexpr uint32_t kNiFlagSkipDraw		= kNiFlagHidden | kNiFlagNotVisible;
+
+	constexpr uint32_t kVtblNiTriStrips		= 0x109CD44;
+	constexpr uint32_t kVtblNiTriShape		= 0x109D454;
+	constexpr uint32_t kVtblNiGeometry		= 0x109E04C;
+	constexpr uint32_t kVtblBSResizable		= 0x109E704;
+	constexpr uint32_t kVtblBSSegmented		= 0x109E834;
+
+	constexpr uint32_t kVtblBSDismemberSkin		= 0x1069A84;
+	constexpr uint32_t kVtblBSShaderPPLighting	= 0x10AE0D0;
+	constexpr uint32_t kVtblLighting30Shader	= 0x10B9910;
+	constexpr uint32_t kVtblHairShaderProperty	= 0x10BABF8;
+
+	constexpr uint32_t kOffDismember_NumParts	= 0x34;
+	constexpr uint32_t kOffDismember_Parts		= 0x38;
+	constexpr uint32_t kOffDismember_Visible	= 0x3C;
+	constexpr uint32_t kOffShader_RefractionPower = 0xE0;
+
+	constexpr uint32_t kShaderFlag1_Refraction		= 1u << 15;
+	constexpr uint32_t kShaderFlag1_FireRefraction	= 1u << 16;
+	constexpr uint32_t kShaderFlag2_RefractionTint	= 1u << (36 - 32);
+	constexpr uint32_t kShaderFlag2_FirstPerson		= 1u << (38 - 32);
+	constexpr uintptr_t kAddrSetAccumulator			= 0xB54AC0;
+	constexpr uintptr_t kAddrSetCurrentAccumulator	= 0xB54B10;
+
+	static_assert(sizeof(BSExtraData) == 0xC);
+	static_assert(sizeof(NiAVObject) == 0x9C);
+	static_assert(offsetof(NiAVObject, m_uiFlags) == 0x30);
+	static_assert(offsetof(NiAVObject, m_kWorld) == 0x68);
+	static_assert(sizeof(NiNode) == 0xAC);
+	static_assert(sizeof(NiGeometry) == 0xC4);
+	static_assert(offsetof(NiGeometry, shaderProp) == 0xA8);
+	static_assert(offsetof(NiGeometry, unkBC) == 0xBC);
+	static_assert(sizeof(BSShaderProperty) == 0x60);
+	static_assert(offsetof(BSShaderProperty, ulFlags) == 0x20);
+	static_assert(offsetof(BSShaderProperty, iLastRenderPassState) == 0x38);
+	static_assert(sizeof(BSShaderAccumulator) == 0x280);
+	static_assert(offsetof(BSShaderAccumulator, bIs1stPerson) == 0x85);
+	static_assert(sizeof(TESMain) == 0xA4);
+	static_assert(offsetof(TESMain, spDraw1stPersonAccum) == 0x8C);
+
+	bool g_hooksInstalled = false;
+	bool g_hooksOk = false;
+	volatile LONG g_enabled = 0;
+	volatile LONG g_partMode = 0;
+	volatile LONG g_partBits = 0;
+	volatile LONG g_disableSuppressFrames = 10;
+	volatile LONG g_disableSuppressFrameBudget = 0;
+
+	struct ExtraRefractionPropertyView : BSExtraData {
+		float fRefractionAmount;
+	};
+	static_assert(sizeof(ExtraRefractionPropertyView) == 0x10);
+	static_assert(offsetof(ExtraRefractionPropertyView, fRefractionAmount) == 0xC);
+
+	NiNode* GetPlayerBodyRootFast() {
+		__try {
+			PlayerCharacter* pPlayer = PlayerCharacter::GetSingleton();
+			NiNode* pBody3p = pPlayer ? pPlayer->Get3DSimple() : nullptr;
+			if (!pBody3p)
+				return nullptr;
+			(void)pBody3p->m_uiFlags.GetField(); // probe read so a dead pointer faults here instead of mid render
+			return pBody3p;
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+			return nullptr;
+		}
+	}
+
+	bool PlayerHasActiveRefraction(float* apRefractionOut) {
+		float fRefraction = 0.0f;
+		__try {
+			PlayerCharacter* pPlayer = PlayerCharacter::GetSingleton();
+			BSExtraData* pExtra = pPlayer
+				? pPlayer->extraDataList.GetExtraData(EXTRA_DATA_TYPE::ExtraRefractionProperty)
+				: nullptr;
+			if (pExtra)
+				fRefraction = reinterpret_cast<ExtraRefractionPropertyView*>(pExtra)->fRefractionAmount;
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+			fRefraction = 0.0f;
+		}
+		if (apRefractionOut)
+			*apRefractionOut = fRefraction;
+		return std::isfinite(fRefraction) && fRefraction > 0.0f;
+	}
+
+	bool IsBodyLeafGeometry(NiAVObject* apObject) {
+		// IsGeometry also accepts particles. Exact types only.
+		const uint32_t uiVtbl = static_cast<uint32_t>(
+			reinterpret_cast<uintptr_t>(*reinterpret_cast<void**>(apObject)));
+		return uiVtbl == kVtblNiTriStrips ||
+		       uiVtbl == kVtblNiTriShape ||
+		       uiVtbl == kVtblNiGeometry ||
+		       uiVtbl == kVtblBSResizable ||
+		       uiVtbl == kVtblBSSegmented;
+	}
+
+	const char* const kNonBodyGeomTokens[] = {
+		"head", "hair", "eye", "brow", "mouth", "teeth", "tongue",
+		"lash", "hat", "helm", "glasses", "mask", "beard", "stache",
+		"facegen", "glove", "hand", "arms01",
+		"glow", "shadow", "emit",
+		"bloodcap",
+		"pipboy",
+	};
+
+	bool IsNonBodyGeom(NiAVObject* apObject) {
+		const char* pName = apObject->GetName();
+		if (!pName)
+			return false;
+		for (const char* pToken : kNonBodyGeomTokens)
+			if (SubStr(pName, pToken))
+				return true;
+		return false;
+	}
+
+	const char* const kPruneNodeTokens[] = {
+		"hair",
+		"earrings",
+		"facegen",
+		"clavicle",
+		"lefthand",
+		"righthand",
+		"weapon",
+		"##nm",
+		"projectilenode",
+		"shellcasingnode",
+		"ingestible",
+		"b42grb",
+		"b42attach",
+		"backpack",
+		"pauldron",
+		"camera3rd",
+		"bnb",
+		"pipboy",
+	};
+
+	bool IsPrunedNode(NiAVObject* apObject) {
+		const char* pName = apObject->GetName();
+		if (!pName)
+			return false;
+		for (const char* pToken : kPruneNodeTokens)
+			if (SubStr(pName, pToken))
+				return true;
+		return false;
+	}
+
+	void RegisterBodyGeometry(NiAVObject* apObject, BSShaderAccumulator* apAccum, uint32_t auiDepth) {
+		if (!apObject || auiDepth > 64)
+			return;
+		const uint32_t uiFlags = apObject->m_uiFlags.GetField();
+		const bool bIsGeom = IsBodyLeafGeometry(apObject);
+		const bool bCulled = (uiFlags & kNiFlagSkipDraw) != 0;
+
+		if (bIsGeom) {
+			if (!bCulled && !IsNonBodyGeom(apObject))
+				apAccum->RegisterObject(static_cast<NiGeometry*>(apObject));
+			return;
+		}
+		NiNode* pNode = apObject->IsNode();
+		if (!pNode)
+			return;
+		if (bCulled || IsPrunedNode(pNode))
+			return;
+		const uint32_t uiChildCount = pNode->GetArrayCount();
+		if (uiChildCount > 1024)
+			return;
+		for (uint32_t i = 0; i < uiChildCount; ++i)
+			if (NiAVObject* pChild = pNode->GetAt(i))
+				RegisterBodyGeometry(pChild, apAccum, auiDepth + 1);
+	}
+
+	bool RegisterBodyGuarded(NiNode* apBody3p, BSShaderAccumulator* apAccum) {
+		__try {
+			RegisterBodyGeometry(apBody3p, apAccum, 0);
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+			return false;
+		}
+		return true;
+	}
+
+	struct TransformBackup {
+		NiAVObject*	pObject;
+		NiMatrix3	kWorldRotate;
+		NiPoint3	kWorldTranslate;
+	};
+
+	struct DismemberPartition {
+		uint8_t		ucEnabled;
+		uint8_t		ucStateChange;
+		uint16_t	usBodyPart;
+	};
+	static_assert(sizeof(DismemberPartition) == 4);
+
+	struct PartitionBackup {
+		DismemberPartition*	pPartition;
+		uint8_t				ucSavedEnabled;
+		uint8_t*			pVisible;
+		uint8_t				ucSavedVisible;
+	};
+
+	struct FlagBackup {
+		uint32_t*	pFlags;
+		uint32_t	uiSavedFlags;
+	};
+
+	struct ShaderBackup {
+		BSShaderProperty*	pShader;
+		uint32_t			uiSavedFlags1;
+		uint32_t			uiSavedFlags2;
+		float				fSavedRefractionPower;
+	};
+
+	constexpr uint32_t kTransformMax	= 1024;
+	constexpr uint32_t kPartitionMax	= 256;
+	constexpr uint32_t kFlagMax			= 512;
+	constexpr uint32_t kShaderMax		= 128;
+
+	// Do not zero these arrays. This runs on the render path.
+	struct InjectionState {
+		bool* pIs1stPerson = nullptr;
+		bool bSavedIs1stPerson = false;
+		TransformBackup kTransforms[kTransformMax];
+		PartitionBackup kPartitions[kPartitionMax];
+		ShaderBackup kShaders[kShaderMax];
+		uint32_t uiTransformCount = 0;
+		uint32_t uiPartitionCount = 0;
+		uint32_t uiShaderCount = 0;
+		bool bActive = false;
+	};
+
+	bool IsFinitePoint(const NiPoint3& arPoint) {
+		return std::isfinite(arPoint.x) && std::isfinite(arPoint.y) && std::isfinite(arPoint.z);
+	}
+
+	bool IsFiniteMatrix(const NiMatrix3& arMatrix) {
+		for (uint32_t i = 0; i < 3; ++i)
+			for (uint32_t j = 0; j < 3; ++j)
+				if (!std::isfinite(arMatrix.m_pEntry[i][j]))
+					return false;
+		return true;
+	}
+
+	bool TryReadWorldTranslate(NiAVObject* apObject, NiPoint3& arOut) {
+		if (!apObject)
+			return false;
+		__try {
+			arOut = apObject->m_kWorld.m_kTranslate;
+			return IsFinitePoint(arOut);
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+			return false;
+		}
+	}
+
+	bool TryReadWorldTransform(NiAVObject* apObject, NiPoint3& arOutTranslate, NiMatrix3& arOutRotate) {
+		if (!apObject)
+			return false;
+		__try {
+			arOutRotate = apObject->m_kWorld.m_kRotate;
+			arOutTranslate = apObject->m_kWorld.m_kTranslate;
+			return IsFinitePoint(arOutTranslate) && IsFiniteMatrix(arOutRotate);
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+			return false;
+		}
+	}
+
+	bool NormalizePoint(NiPoint3& arP) {
+		if (!IsFinitePoint(arP))
+			return false;
+		const double fLenSq =
+			static_cast<double>(arP.x) * arP.x +
+			static_cast<double>(arP.y) * arP.y +
+			static_cast<double>(arP.z) * arP.z;
+		if (!std::isfinite(fLenSq) || fLenSq < 0.000001)
+			return false;
+		const float fInvLen = static_cast<float>(1.0 / std::sqrt(fLenSq));
+		arP.x *= fInvLen;
+		arP.y *= fInvLen;
+		arP.z *= fInvLen;
+		return true;
+	}
+
+	// dir = col 0, right = col 2
+	bool CameraPitchDeltaMatrix(const NiMatrix3& arCamRot, NiMatrix3& arOut) {
+		NiPoint3 kCamDir = arCamRot.GetCol(0);
+		NiPoint3 kCamRight = arCamRot.GetCol(2);
+		if (!NormalizePoint(kCamDir) || !NormalizePoint(kCamRight))
+			return false;
+
+		NiPoint3 kFlatDir(kCamDir.x, kCamDir.y, 0.0f);
+		if (!NormalizePoint(kFlatDir))
+			return false;
+
+		const float fSin = kFlatDir.Cross(kCamDir).Dot(kCamRight);
+		const float fCos = kFlatDir.Dot(kCamDir);
+		const float fAngle = std::atan2(fSin, fCos);
+		if (!std::isfinite(fAngle) || std::fabs(fAngle) < 0.000001f)
+			return false;
+
+		// MakeRotation builds the transpose of what this math wants, hence the negated angle
+		arOut.MakeRotation(-fAngle, kCamRight);
+		return true;
+	}
+
+	void RestoreTransforms(TransformBackup* apBackups, uint32_t auiCount) {
+		__try {
+			while (auiCount) {
+				--auiCount;
+				if (NiAVObject* pObject = apBackups[auiCount].pObject) {
+					pObject->m_kWorld.m_kRotate = apBackups[auiCount].kWorldRotate;
+					pObject->m_kWorld.m_kTranslate = apBackups[auiCount].kWorldTranslate;
+				}
+			}
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+		}
+	}
+
+	bool TransformObjectTree(NiAVObject* apObject, const NiPoint3& arDelta,
+			const NiPoint3& arRotateSourcePivot, const NiPoint3& arRotateTargetPivot,
+			const NiMatrix3& arCameraDeltaRot, bool abRotateWithCamera,
+			TransformBackup* apBackups, uint32_t auiMax, uint32_t& arCount, uint32_t auiDepth) {
+		if (!apObject || auiDepth > 64)
+			return true;
+
+		const bool bIsGeom = IsBodyLeafGeometry(apObject);
+		NiNode* pNode = bIsGeom ? nullptr : apObject->IsNode();
+		if (!bIsGeom && !pNode)
+			return true;
+
+		if (arCount >= auiMax)
+			return false;
+
+		NiTransform& rWorld = apObject->m_kWorld;
+		apBackups[arCount].pObject = apObject;
+		apBackups[arCount].kWorldRotate = rWorld.m_kRotate;
+		apBackups[arCount].kWorldTranslate = rWorld.m_kTranslate;
+		++arCount;
+
+		if (abRotateWithCamera) {
+			const NiPoint3 kRel = rWorld.m_kTranslate - arRotateSourcePivot;
+			rWorld.m_kTranslate = arRotateTargetPivot + arCameraDeltaRot * kRel;
+			rWorld.m_kRotate = arCameraDeltaRot * rWorld.m_kRotate;
+		} else {
+			rWorld.m_kTranslate += arDelta;
+		}
+
+		if (!pNode)
+			return true;
+		const uint32_t uiChildCount = pNode->GetArrayCount();
+		if (uiChildCount > 1024)
+			return true;
+		for (uint32_t i = 0; i < uiChildCount; ++i)
+			if (NiAVObject* pChild = pNode->GetAt(i))
+				if (!TransformObjectTree(pChild, arDelta,
+						arRotateSourcePivot, arRotateTargetPivot,
+						arCameraDeltaRot, abRotateWithCamera, apBackups, auiMax, arCount, auiDepth + 1))
+					return false;
+		return true;
+	}
+
+	bool ApplyTransformsGuarded(NiNode* apBody3p, const NiPoint3& arDelta,
+			const NiPoint3& arRotateSourcePivot, const NiPoint3& arRotateTargetPivot,
+			const NiMatrix3& arCameraDeltaRot, bool abRotateWithCamera,
+			TransformBackup* apBackups, uint32_t auiMax, uint32_t& arCount) {
+		arCount = 0;
+		if (!abRotateWithCamera && arDelta.SqrLength() < 0.0001f)
+			return true;
+
+		bool bOk = false;
+		__try {
+			bOk = TransformObjectTree(apBody3p, arDelta,
+				arRotateSourcePivot, arRotateTargetPivot,
+				arCameraDeltaRot, abRotateWithCamera, apBackups, auiMax, arCount, 0);
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+			bOk = false;
+		}
+		if (!bOk)
+			RestoreTransforms(apBackups, arCount);
+		return bOk;
+	}
+
+	uint16_t NormalizeBodyPart(uint16_t ausBodyPart) {
+		if (ausBodyPart >= 1000 && (ausBodyPart % 1000) == 0)
+			return ausBodyPart / 1000;
+		if (ausBodyPart >= 100 && ausBodyPart < 1000)
+			return ausBodyPart % 100; // caps fold onto the base part
+		return ausBodyPart;
+	}
+
+	uint32_t PartBit(uint16_t ausBodyPart) {
+		const uint16_t usPart = NormalizeBodyPart(ausBodyPart);
+		return usPart < 32 ? (1u << usPart) : 0;
+	}
+
+	struct CullConfig {
+		LONG iPartMode;
+		LONG iPartBits;
+	};
+
+	CullConfig GetCullConfig() {
+		CullConfig kConfig;
+		kConfig.iPartMode = g_partMode;
+		kConfig.iPartBits = g_partBits;
+		return kConfig;
+	}
+
+	bool IsKeptPart(uint16_t ausBodyPart, const CullConfig& arConfig) {
+		const uint32_t uiBit = PartBit(ausBodyPart);
+		if (arConfig.iPartMode == 2)
+			return !(uiBit && (static_cast<uint32_t>(arConfig.iPartBits) & uiBit));
+		return uiBit && (static_cast<uint32_t>(arConfig.iPartBits) & uiBit);
+	}
+
+	bool RecomputeDismemberVisible(uint8_t* apSkin) {
+		uint32_t uiNumParts = *reinterpret_cast<uint32_t*>(apSkin + kOffDismember_NumParts);
+		DismemberPartition* pParts = *reinterpret_cast<DismemberPartition**>(apSkin + kOffDismember_Parts);
+		if (!pParts || uiNumParts > 128)
+			return false;
+
+		uint8_t ucVisible = 0;
+		for (uint32_t i = 0; i < uiNumParts; ++i)
+			ucVisible |= pParts[i].ucEnabled ? 1 : 0;
+		*(apSkin + kOffDismember_Visible) = ucVisible;
+		return true;
+	}
+
+	bool CullPartitionsForGeom(NiGeometry* apGeom, const CullConfig& arConfig,
+			PartitionBackup* apBackups, uint32_t auiMax, uint32_t& arCount) {
+		// unkBC is the skin instance slot
+		uint8_t* pSkin = reinterpret_cast<uint8_t*>(apGeom->unkBC);
+		if (!pSkin || static_cast<uint32_t>(reinterpret_cast<uintptr_t>(
+				*reinterpret_cast<void**>(pSkin))) != kVtblBSDismemberSkin)
+			return true;
+
+		uint32_t uiNumParts = *reinterpret_cast<uint32_t*>(pSkin + kOffDismember_NumParts);
+		DismemberPartition* pParts = *reinterpret_cast<DismemberPartition**>(pSkin + kOffDismember_Parts);
+		uint8_t* pVisible = pSkin + kOffDismember_Visible;
+		if (!pParts || uiNumParts > 128)
+			return true;
+
+		for (uint32_t i = 0; i < uiNumParts; ++i) {
+			if (!pParts[i].ucEnabled || IsKeptPart(pParts[i].usBodyPart, arConfig))
+				continue;
+			if (arCount >= auiMax)
+				return false;
+			apBackups[arCount].pPartition = &pParts[i];
+			apBackups[arCount].ucSavedEnabled = pParts[i].ucEnabled;
+			apBackups[arCount].pVisible = pVisible;
+			apBackups[arCount].ucSavedVisible = *pVisible;
+			++arCount;
+			pParts[i].ucEnabled = 0;
+		}
+		return RecomputeDismemberVisible(pSkin);
+	}
+
+	void RestorePartitions(PartitionBackup* apBackups, uint32_t auiCount) {
+		__try {
+			while (auiCount) {
+				--auiCount;
+				if (apBackups[auiCount].pPartition)
+					apBackups[auiCount].pPartition->ucEnabled = apBackups[auiCount].ucSavedEnabled;
+				if (apBackups[auiCount].pVisible)
+					*apBackups[auiCount].pVisible = apBackups[auiCount].ucSavedVisible;
+			}
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+		}
+	}
+
+	void RestoreFlags(FlagBackup* apBackups, uint32_t auiCount) {
+		__try {
+			while (auiCount) {
+				--auiCount;
+				if (apBackups[auiCount].pFlags)
+					*apBackups[auiCount].pFlags = apBackups[auiCount].uiSavedFlags;
+			}
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+		}
+	}
+
+	bool HidePreviewObject(NiAVObject* apObject, FlagBackup* apBackups, uint32_t auiMax, uint32_t& arCount) {
+		uint32_t& rFlags = apObject->m_uiFlags.GetField();
+		const uint32_t uiSaved = rFlags;
+		if (uiSaved & kNiFlagSkipDraw)
+			return true;
+		if (arCount >= auiMax)
+			return false;
+		apBackups[arCount].pFlags = &rFlags;
+		apBackups[arCount].uiSavedFlags = uiSaved;
+		++arCount;
+		rFlags = uiSaved | kNiFlagSkipDraw;
+		return true;
+	}
+
+	bool CullTree(NiAVObject* apObject, const CullConfig& arConfig,
+			PartitionBackup* apPartitionBackups, uint32_t auiMaxPartitions, uint32_t& arPartitionCount,
+			FlagBackup* apFlagBackups, uint32_t auiMaxFlags, uint32_t& arFlagCount, uint32_t auiDepth) {
+		if (!apObject || auiDepth > 64)
+			return true;
+
+		const bool bIsGeom = IsBodyLeafGeometry(apObject);
+		NiNode* pNode = bIsGeom ? nullptr : apObject->IsNode();
+		if (bIsGeom) {
+			NiGeometry* pGeom = static_cast<NiGeometry*>(apObject);
+			if (!CullPartitionsForGeom(pGeom, arConfig, apPartitionBackups, auiMaxPartitions, arPartitionCount))
+				return false;
+			return (apFlagBackups && arConfig.iPartMode == 1 && IsNonBodyGeom(apObject))
+				? HidePreviewObject(apObject, apFlagBackups, auiMaxFlags, arFlagCount)
+				: true;
+		}
+		if (!pNode)
+			return true;
+
+		if (IsPrunedNode(pNode)) {
+			return (apFlagBackups && arConfig.iPartMode == 1)
+				? HidePreviewObject(pNode, apFlagBackups, auiMaxFlags, arFlagCount)
+				: true;
+		}
+
+		const uint32_t uiChildCount = pNode->GetArrayCount();
+		if (uiChildCount > 1024)
+			return true;
+		for (uint32_t i = 0; i < uiChildCount; ++i)
+			if (NiAVObject* pChild = pNode->GetAt(i))
+				if (!CullTree(pChild, arConfig,
+						apPartitionBackups, auiMaxPartitions, arPartitionCount,
+						apFlagBackups, auiMaxFlags, arFlagCount, auiDepth + 1))
+					return false;
+		return true;
+	}
+
+	bool CullPartitionsGuarded(NiNode* apBody3p, const CullConfig& arConfig,
+			PartitionBackup* apBackups, uint32_t auiMax, uint32_t& arCount) {
+		arCount = 0;
+		uint32_t uiUnusedFlagCount = 0;
+		bool bOk = false;
+		__try {
+			bOk = CullTree(apBody3p, arConfig, apBackups, auiMax, arCount,
+				nullptr, 0, uiUnusedFlagCount, 0);
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+			bOk = false;
+		}
+		if (!bOk)
+			RestorePartitions(apBackups, arCount);
+		return bOk;
+	}
+
+	bool ApplyCullPreviewBracket(NiNode* apBody3p, const CullConfig& arConfig,
+			PartitionBackup* apPartitionBackups, uint32_t auiMaxPartitions, uint32_t& arPartitionCount,
+			FlagBackup* apFlagBackups, uint32_t auiMaxFlags, uint32_t& arFlagCount) {
+		arPartitionCount = 0;
+		arFlagCount = 0;
+		if (!arConfig.iPartMode)
+			return true;
+		if (!apBody3p)
+			return false;
+
+		bool bOk = false;
+		__try {
+			bOk = CullTree(apBody3p, arConfig,
+				apPartitionBackups, auiMaxPartitions, arPartitionCount,
+				apFlagBackups, auiMaxFlags, arFlagCount, 0);
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+			bOk = false;
+		}
+		if (!bOk) {
+			RestoreFlags(apFlagBackups, arFlagCount);
+			RestorePartitions(apPartitionBackups, arPartitionCount);
+			arPartitionCount = 0;
+			arFlagCount = 0;
+		}
+		return bOk;
+	}
+
+	bool IsRefractionShader(BSShaderProperty* apShader) {
+		if (!apShader)
+			return false;
+		const uint32_t uiVtbl = static_cast<uint32_t>(
+			reinterpret_cast<uintptr_t>(*reinterpret_cast<void**>(apShader)));
+		return uiVtbl == kVtblBSShaderPPLighting ||
+		       uiVtbl == kVtblLighting30Shader ||
+		       uiVtbl == kVtblHairShaderProperty;
+	}
+
+	bool HasShaderBackup(const ShaderBackup* apBackups, uint32_t auiCount, BSShaderProperty* apShader) {
+		for (uint32_t i = 0; i < auiCount; ++i)
+			if (apBackups[i].pShader == apShader)
+				return true;
+		return false;
+	}
+
+	bool PatchRefractionShaderForGeom(NiGeometry* apGeom, float afRefraction,
+			ShaderBackup* apBackups, uint32_t auiMax, uint32_t& arCount) {
+		BSShaderProperty* pShader = apGeom->shaderProp;
+		if (!IsRefractionShader(pShader))
+			return true;
+		if (HasShaderBackup(apBackups, arCount, pShader))
+			return true;
+		if (arCount >= auiMax)
+			return false;
+
+		uint32_t& rFlags1 = pShader->ulFlags[0].GetField();
+		uint32_t& rFlags2 = pShader->ulFlags[1].GetField();
+		float* pRefractionPower = reinterpret_cast<float*>(
+			reinterpret_cast<uint8_t*>(pShader) + kOffShader_RefractionPower);
+
+		apBackups[arCount].pShader = pShader;
+		apBackups[arCount].uiSavedFlags1 = rFlags1;
+		apBackups[arCount].uiSavedFlags2 = rFlags2;
+		apBackups[arCount].fSavedRefractionPower = *pRefractionPower;
+		++arCount;
+
+		rFlags1 = (rFlags1 | kShaderFlag1_Refraction) & ~kShaderFlag1_FireRefraction;
+		rFlags2 = (rFlags2 & ~kShaderFlag2_RefractionTint) | kShaderFlag2_FirstPerson;
+		*pRefractionPower = afRefraction;
+		pShader->InvalidateState();
+		return true;
+	}
+
+	bool PatchRefractionTree(NiAVObject* apObject, float afRefraction,
+			ShaderBackup* apBackups, uint32_t auiMax, uint32_t& arCount, uint32_t auiDepth) {
+		if (!apObject || auiDepth > 64)
+			return true;
+
+		const uint32_t uiFlags = apObject->m_uiFlags.GetField();
+		const bool bIsGeom = IsBodyLeafGeometry(apObject);
+		NiNode* pNode = bIsGeom ? nullptr : apObject->IsNode();
+		const bool bCulled = (uiFlags & kNiFlagSkipDraw) != 0;
+
+		if (bIsGeom) {
+			if (bCulled || IsNonBodyGeom(apObject))
+				return true;
+			return PatchRefractionShaderForGeom(static_cast<NiGeometry*>(apObject),
+				afRefraction, apBackups, auiMax, arCount);
+		}
+		if (!pNode)
+			return true;
+		if (bCulled || IsPrunedNode(pNode))
+			return true;
+
+		const uint32_t uiChildCount = pNode->GetArrayCount();
+		if (uiChildCount > 1024)
+			return true;
+		for (uint32_t i = 0; i < uiChildCount; ++i)
+			if (NiAVObject* pChild = pNode->GetAt(i))
+				if (!PatchRefractionTree(pChild, afRefraction, apBackups, auiMax, arCount, auiDepth + 1))
+					return false;
+		return true;
+	}
+
+	void RestoreShaders(ShaderBackup* apBackups, uint32_t auiCount) {
+		__try {
+			while (auiCount) {
+				--auiCount;
+				BSShaderProperty* pShader = apBackups[auiCount].pShader;
+				if (!pShader)
+					continue;
+				pShader->ulFlags[0] = apBackups[auiCount].uiSavedFlags1;
+				pShader->ulFlags[1] = apBackups[auiCount].uiSavedFlags2;
+				*reinterpret_cast<float*>(
+					reinterpret_cast<uint8_t*>(pShader) + kOffShader_RefractionPower) =
+					apBackups[auiCount].fSavedRefractionPower;
+				pShader->InvalidateState();
+			}
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+		}
+	}
+
+	bool PatchRefractionGuarded(NiNode* apBody3p, float afRefraction,
+			ShaderBackup* apBackups, uint32_t auiMax, uint32_t& arCount) {
+		arCount = 0;
+		if (afRefraction <= 0.0f)
+			return true;
+		if (afRefraction > 1.0f)
+			afRefraction = 1.0f;
+
+		bool bOk = false;
+		__try {
+			bOk = PatchRefractionTree(apBody3p, afRefraction, apBackups, auiMax, arCount, 0);
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+			bOk = false;
+		}
+		if (!bOk)
+			RestoreShaders(apBackups, arCount);
+		return bOk;
+	}
+
+	void RestoreInjectedBody(InjectionState& arState) {
+		if (!arState.bActive)
+			return;
+		__try {
+			if (arState.uiShaderCount)
+				RestoreShaders(arState.kShaders, arState.uiShaderCount);
+			if (arState.uiPartitionCount)
+				RestorePartitions(arState.kPartitions, arState.uiPartitionCount);
+			if (arState.uiTransformCount)
+				RestoreTransforms(arState.kTransforms, arState.uiTransformCount);
+			if (arState.pIs1stPerson)
+				*arState.pIs1stPerson = arState.bSavedIs1stPerson;
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+		}
+		arState.bActive = false;
+	}
+
+	void InjectBodyIntoAccum(NiCamera* apCamera, BSShaderAccumulator* apAccum,
+			InjectionState& arState, float afRefraction) {
+		if (!apCamera)
+			return;
+		NiNode* pBody3p = GetPlayerBodyRootFast();
+		if (!pBody3p)
+			return;
+
+		NiCamera* pWorldCamera = TESMain::GetWorldRootCamera();
+		NiPoint3 kCamPos, kWorldCamPos;
+		NiMatrix3 kCameraDeltaRot;
+		NiMatrix3 kCamRot;
+		const bool bHaveCamPos = TryReadWorldTransform(apCamera, kCamPos, kCamRot);
+		const bool bRotateWithCamera = bHaveCamPos && CameraPitchDeltaMatrix(kCamRot, kCameraDeltaRot);
+		if ((!bHaveCamPos && !TryReadWorldTranslate(apCamera, kCamPos)) ||
+				!TryReadWorldTranslate(pWorldCamera, kWorldCamPos))
+			return;
+
+		// the callers finally block puts this back
+		arState.pIs1stPerson = &apAccum->bIs1stPerson;
+		arState.bSavedIs1stPerson = apAccum->bIs1stPerson;
+		arState.bActive = true;
+
+		apAccum->bIs1stPerson = true;
+		CdeclCall(kAddrSetAccumulator, apAccum); // BSShaderManager::SetAccumulator
+		CdeclCall(kAddrSetCurrentAccumulator, apAccum); // BSShaderManager::SetCurrentAccumulator
+		apAccum->StartAccumulating(apCamera);
+
+		const NiPoint3 kDelta = kCamPos - kWorldCamPos;
+		if (!ApplyTransformsGuarded(pBody3p, kDelta, kWorldCamPos, kCamPos,
+				kCameraDeltaRot, bRotateWithCamera,
+				arState.kTransforms, kTransformMax, arState.uiTransformCount)) {
+			arState.uiTransformCount = 0;
+			return;
+		}
+
+		const CullConfig kConfig = GetCullConfig();
+		if (kConfig.iPartMode) {
+			if (!CullPartitionsGuarded(pBody3p, kConfig,
+					arState.kPartitions, kPartitionMax, arState.uiPartitionCount)) {
+				arState.uiPartitionCount = 0;
+				return;
+			}
+		} else {
+			arState.uiPartitionCount = 0;
+		}
+
+		if (afRefraction > 0.0f &&
+				!PatchRefractionGuarded(pBody3p, afRefraction,
+					arState.kShaders, kShaderMax, arState.uiShaderCount)) {
+			arState.uiShaderCount = 0;
+			return;
+		}
+
+		RegisterBodyGuarded(pBody3p, apAccum);
+	}
+
+	constexpr uintptr_t kAddrDrawScene		= 0x873200;
+	constexpr uintptr_t kAddrRenderScene	= 0xB6C0D0;
+	constexpr uintptr_t kAddrRenderNormals	= 0xB64570;
+
+	constexpr uintptr_t kSiteWorldCull1		= 0x870AE8;	// Render::Wireframe
+	constexpr uintptr_t kSiteWorldCull2		= 0x870E18;	// Render::Default
+	constexpr uintptr_t kSiteRenderScene1	= 0x87550F;	// Render1stPerson
+	constexpr uintptr_t kSiteRenderScene2	= 0x8755F4;	// Render1stPerson
+	// Leave 0x875801 and 0x875AED alone. The overlay is single pass.
+	constexpr uintptr_t kSiteRenderNormals	= 0x87590A;	// Render1stPerson
+
+	enum HookIndex : uint32_t {
+		kHookWorldCull1,
+		kHookWorldCull2,
+		kHookRenderScene1,
+		kHookRenderScene2,
+		kHookRenderNormals,
+		kHookCount,
+	};
+	HookUtils::CallDetour g_callDetours[kHookCount];
+
+	void RestoreBodyFlagsGuarded(uint32_t* apFlags, uint32_t auiSaved) {
+		__try {
+			*apFlags = auiSaved;
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+		}
+	}
+
+	template <uint32_t aiHookIndex>
+	void __fastcall HookedDrawScene(void* apThis, void* edx, void* apSun,
+			int abRenderHands, int abIsWireframe, int abIsInVATS) {
+		uint32_t* pBodyFlags = nullptr;
+		uint32_t uiSaved = 0;
+		PartitionBackup kPreviewPartitions[kPartitionMax];
+		FlagBackup kPreviewFlags[kFlagMax];
+		uint32_t uiPreviewPartitionCount = 0;
+		uint32_t uiPreviewFlagCount = 0;
+		const LONG iSuppressFrames = g_disableSuppressFrameBudget;
+		const bool bSuppressBody = g_enabled || iSuppressFrames > 0;
+		if (bSuppressBody) {
+			if (NiNode* pBody3p = GetPlayerBodyRootFast()) {
+				__try {
+					pBodyFlags = &pBody3p->m_uiFlags.GetField();
+					uiSaved = *pBodyFlags;
+					*pBodyFlags = uiSaved | kNiFlagHidden;
+				}
+				__except (EXCEPTION_EXECUTE_HANDLER) {
+					pBodyFlags = nullptr;
+				}
+			}
+		} else {
+			const CullConfig kPreviewConfig = GetCullConfig();
+			if (kPreviewConfig.iPartMode) {
+				if (NiNode* pBody3p = GetPlayerBodyRootFast())
+					ApplyCullPreviewBracket(pBody3p, kPreviewConfig,
+						kPreviewPartitions, kPartitionMax, uiPreviewPartitionCount,
+						kPreviewFlags, kFlagMax, uiPreviewFlagCount);
+			}
+		}
+		__try {
+			ThisCall(g_callDetours[aiHookIndex].GetOverwrittenAddr(),
+				apThis, apSun, abRenderHands, abIsWireframe, abIsInVATS);
+		}
+		__finally {
+			if (uiPreviewFlagCount)
+				RestoreFlags(kPreviewFlags, uiPreviewFlagCount);
+			if (uiPreviewPartitionCount)
+				RestorePartitions(kPreviewPartitions, uiPreviewPartitionCount);
+			if (iSuppressFrames > 0)
+				InterlockedDecrement(&g_disableSuppressFrameBudget);
+			if (pBodyFlags)
+				RestoreBodyFlagsGuarded(pBodyFlags, uiSaved);
+		}
+	}
+
+	// Keep this out of the hook frame. Its locals are about 60 KB.
+	DECLSPEC_NOINLINE void CallWithInjectedBody(bool abRefractionPass,
+			uintptr_t auiOriginalTarget, NiCamera* apCamera,
+			BSShaderAccumulator* apAccum, void* apTexture) {
+		InjectionState kInjected;
+		float fRefraction = 0.0f;
+		const bool bHasRefraction = PlayerHasActiveRefraction(&fRefraction);
+		__try {
+			if (bHasRefraction == abRefractionPass)
+				InjectBodyIntoAccum(apCamera, apAccum, kInjected, abRefractionPass ? fRefraction : 0.0f);
+			if (abRefractionPass)
+				ThisCall(auiOriginalTarget, apAccum, apCamera, apTexture);
+			else
+				CdeclCall(auiOriginalTarget, apCamera, apAccum);
+		}
+		__finally {
+			RestoreInjectedBody(kInjected);
+		}
+	}
+
+	bool IsViewmodelAccum(BSShaderAccumulator* apAccum) {
+		if (!apAccum)
+			return false;
+		TESMain* pMain = TESMain::GetSingleton();
+		return pMain && apAccum == pMain->spDraw1stPersonAccum;
+	}
+
+	template <uint32_t aiHookIndex>
+	void __cdecl HookedRenderScene(NiCamera* apCamera, BSShaderAccumulator* apAccum) {
+		const uintptr_t uiOriginalTarget = g_callDetours[aiHookIndex].GetOverwrittenAddr();
+		if (g_enabled && IsViewmodelAccum(apAccum)) {
+			CallWithInjectedBody(false, uiOriginalTarget, apCamera, apAccum, nullptr);
+			return;
+		}
+		CdeclCall(uiOriginalTarget, apCamera, apAccum);
+	}
+
+	template <uint32_t aiHookIndex>
+	void __fastcall HookedRenderNormals(BSShaderAccumulator* apAccum, void* edx,
+			NiCamera* apCamera, void* apTexture) {
+		(void)edx;
+		const uintptr_t uiOriginalTarget = g_callDetours[aiHookIndex].GetOverwrittenAddr();
+		if (g_enabled && IsViewmodelAccum(apAccum)) {
+			CallWithInjectedBody(true, uiOriginalTarget, apCamera, apAccum, apTexture);
+			return;
+		}
+		ThisCall(uiOriginalTarget, apAccum, apCamera, apTexture);
+	}
+
+	uintptr_t ReadCallTarget(uintptr_t auiSite) {
+		if (*reinterpret_cast<uint8_t*>(auiSite) != 0xE8)
+			return 0;
+		return *reinterpret_cast<int32_t*>(auiSite + 1) + auiSite + 5;
+	}
+
+	struct HookSite {
+		uint32_t uiIndex;
+		uintptr_t uiSite;
+		uintptr_t uiVanillaTarget;
+		void* pHook;
+		const char* pName;
+	};
+
+}
+
+void Install() {
+	if (g_hooksInstalled)
+		return;
+	g_hooksInstalled = true;
+
+	const HookSite kSites[] = {
+		{ kHookWorldCull1, kSiteWorldCull1, kAddrDrawScene,
+			reinterpret_cast<void*>(&HookedDrawScene<kHookWorldCull1>), "world-cull 0x870AE8" },
+		{ kHookWorldCull2, kSiteWorldCull2, kAddrDrawScene,
+			reinterpret_cast<void*>(&HookedDrawScene<kHookWorldCull2>), "world-cull 0x870E18" },
+		{ kHookRenderScene1, kSiteRenderScene1, kAddrRenderScene,
+			reinterpret_cast<void*>(&HookedRenderScene<kHookRenderScene1>), "viewmodel 0x87550F" },
+		{ kHookRenderScene2, kSiteRenderScene2, kAddrRenderScene,
+			reinterpret_cast<void*>(&HookedRenderScene<kHookRenderScene2>), "viewmodel 0x8755F4" },
+		{ kHookRenderNormals, kSiteRenderNormals, kAddrRenderNormals,
+			reinterpret_cast<void*>(&HookedRenderNormals<kHookRenderNormals>), "refraction 0x87590A" },
+	};
+
+	// Fail closed on any foreign hook. Chaining an unknown overlay here means double rendering.
+	for (const HookSite& rSite : kSites) {
+		const uintptr_t uiCurrent = ReadCallTarget(rSite.uiSite);
+		if (uiCurrent != rSite.uiVanillaTarget) {
+			_MESSAGE("PlayerBodyOverlay: %s already modified (target 0x%08X) - overlay disabled",
+				rSite.pName, uiCurrent);
+			g_hooksOk = false;
+			return;
+		}
+	}
+	for (const HookSite& rSite : kSites)
+		g_callDetours[rSite.uiIndex].ReplaceCall(rSite.uiSite, rSite.pHook);
+	for (const HookSite& rSite : kSites) {
+		if (ReadCallTarget(rSite.uiSite) != reinterpret_cast<uintptr_t>(rSite.pHook)) {
+			_MESSAGE("PlayerBodyOverlay: %s patch did not stick - overlay disabled", rSite.pName);
+			g_hooksOk = false;
+			return;
+		}
+	}
+
+	_MESSAGE("PlayerBodyOverlay: render hooks installed (5 sites)");
+	g_hooksOk = true;
+}
+
+void Reset() {
+	InterlockedExchange(&g_enabled, 0);
+	InterlockedExchange(&g_disableSuppressFrameBudget, 0);
+	InterlockedExchange(&g_partMode, 0);
+	InterlockedExchange(&g_partBits, 0);
+}
+
+int32_t SetEnabled(bool abEnable, int32_t aiDisableSuppressFrames) {
+	Install();
+	const LONG iPrevious = g_enabled;
+
+	if (aiDisableSuppressFrames >= 0) {
+		if (aiDisableSuppressFrames > 60)
+			aiDisableSuppressFrames = 60;
+		InterlockedExchange(&g_disableSuppressFrames, aiDisableSuppressFrames);
+	}
+
+	if (abEnable) {
+		if (!g_hooksOk)
+			return -1;
+		InterlockedExchange(&g_enabled, 1);
+		InterlockedExchange(&g_disableSuppressFrameBudget, 0);
+	} else {
+		InterlockedExchange(&g_enabled, 0);
+		if (iPrevious)
+			InterlockedExchange(&g_disableSuppressFrameBudget, g_disableSuppressFrames);
+	}
+	return iPrevious;
+}
+
+bool IsEnabled() {
+	return g_enabled != 0;
+}
+
+uint32_t SetCullParts(int32_t aiMode, uint32_t auiPartBits) {
+	Install();
+	const LONG iPreviousBits = g_partBits;
+	if (aiMode < 0 || aiMode > 2)
+		aiMode = 0;
+	if (aiMode && !g_hooksOk)
+		return static_cast<uint32_t>(iPreviousBits);
+	InterlockedExchange(&g_partMode, aiMode);
+	InterlockedExchange(&g_partBits, static_cast<LONG>(aiMode ? auiPartBits : 0));
+	return static_cast<uint32_t>(iPreviousBits);
+}
+
+uint32_t GetCullPartBits() {
+	return static_cast<uint32_t>(g_partBits);
+}
+
+uint32_t BuildPartBits(const int32_t* apParts, uint32_t auiCount) {
+	uint32_t uiBits = 0;
+	for (uint32_t i = 0; i < auiCount; ++i)
+		if (apParts[i] >= 0 && apParts[i] <= UINT16_MAX)
+			uiBits |= PartBit(static_cast<uint16_t>(apParts[i]));
+	return uiBits;
+}
+
+}

--- a/JG/internal/JG/PlayerBodyOverlay.cpp
+++ b/JG/internal/JG/PlayerBodyOverlay.cpp
@@ -75,32 +75,17 @@ namespace {
 	static_assert(offsetof(ExtraRefractionPropertyView, fRefractionAmount) == 0xC);
 
 	NiNode* GetPlayerBodyRootFast() {
-		__try {
-			PlayerCharacter* pPlayer = PlayerCharacter::GetSingleton();
-			NiNode* pBody3p = pPlayer ? pPlayer->Get3DSimple() : nullptr;
-			if (!pBody3p)
-				return nullptr;
-			(void)pBody3p->m_uiFlags.GetField(); // probe read so a dead pointer faults here instead of mid render
-			return pBody3p;
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
-			return nullptr;
-		}
+		return PlayerCharacter::GetSingleton()->Get3D(false);
 	}
 
 	bool PlayerHasActiveRefraction(float* apRefractionOut) {
 		float fRefraction = 0.0f;
-		__try {
-			PlayerCharacter* pPlayer = PlayerCharacter::GetSingleton();
-			BSExtraData* pExtra = pPlayer
-				? pPlayer->extraDataList.GetExtraData(EXTRA_DATA_TYPE::ExtraRefractionProperty)
-				: nullptr;
-			if (pExtra)
-				fRefraction = reinterpret_cast<ExtraRefractionPropertyView*>(pExtra)->fRefractionAmount;
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
-			fRefraction = 0.0f;
-		}
+		PlayerCharacter* pPlayer = PlayerCharacter::GetSingleton();
+		BSExtraData* pExtra = pPlayer
+			? pPlayer->extraDataList.GetExtraData(EXTRA_DATA_TYPE::ExtraRefractionProperty)
+			: nullptr;
+		if (pExtra)
+			fRefraction = reinterpret_cast<ExtraRefractionPropertyView*>(pExtra)->fRefractionAmount;
 		if (apRefractionOut)
 			*apRefractionOut = fRefraction;
 		return std::isfinite(fRefraction) && fRefraction > 0.0f;
@@ -193,12 +178,7 @@ namespace {
 	}
 
 	bool RegisterBodyGuarded(NiNode* apBody3p, BSShaderAccumulator* apAccum) {
-		__try {
-			RegisterBodyGeometry(apBody3p, apAccum, 0);
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
-			return false;
-		}
+		RegisterBodyGeometry(apBody3p, apAccum, 0);
 		return true;
 	}
 
@@ -267,26 +247,18 @@ namespace {
 	bool TryReadWorldTranslate(NiAVObject* apObject, NiPoint3& arOut) {
 		if (!apObject)
 			return false;
-		__try {
-			arOut = apObject->m_kWorld.m_kTranslate;
-			return IsFinitePoint(arOut);
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
-			return false;
-		}
+
+		arOut = apObject->m_kWorld.m_kTranslate;
+		return IsFinitePoint(arOut);
 	}
 
 	bool TryReadWorldTransform(NiAVObject* apObject, NiPoint3& arOutTranslate, NiMatrix3& arOutRotate) {
 		if (!apObject)
 			return false;
-		__try {
-			arOutRotate = apObject->m_kWorld.m_kRotate;
-			arOutTranslate = apObject->m_kWorld.m_kTranslate;
-			return IsFinitePoint(arOutTranslate) && IsFiniteMatrix(arOutRotate);
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
-			return false;
-		}
+
+		arOutRotate = apObject->m_kWorld.m_kRotate;
+		arOutTranslate = apObject->m_kWorld.m_kTranslate;
+		return IsFinitePoint(arOutTranslate) && IsFiniteMatrix(arOutRotate);
 	}
 
 	bool NormalizePoint(NiPoint3& arP) {
@@ -328,16 +300,12 @@ namespace {
 	}
 
 	void RestoreTransforms(TransformBackup* apBackups, uint32_t auiCount) {
-		__try {
-			while (auiCount) {
-				--auiCount;
-				if (NiAVObject* pObject = apBackups[auiCount].pObject) {
-					pObject->m_kWorld.m_kRotate = apBackups[auiCount].kWorldRotate;
-					pObject->m_kWorld.m_kTranslate = apBackups[auiCount].kWorldTranslate;
-				}
+		while (auiCount) {
+			--auiCount;
+			if (NiAVObject* pObject = apBackups[auiCount].pObject) {
+				pObject->m_kWorld.m_kRotate = apBackups[auiCount].kWorldRotate;
+				pObject->m_kWorld.m_kTranslate = apBackups[auiCount].kWorldTranslate;
 			}
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
 		}
 	}
 
@@ -393,14 +361,9 @@ namespace {
 			return true;
 
 		bool bOk = false;
-		__try {
-			bOk = TransformObjectTree(apBody3p, arDelta,
-				arRotateSourcePivot, arRotateTargetPivot,
-				arCameraDeltaRot, abRotateWithCamera, apBackups, auiMax, arCount, 0);
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
-			bOk = false;
-		}
+		bOk = TransformObjectTree(apBody3p, arDelta,
+			arRotateSourcePivot, arRotateTargetPivot,
+			arCameraDeltaRot, abRotateWithCamera, apBackups, auiMax, arCount, 0);
 		if (!bOk)
 			RestoreTransforms(apBackups, arCount);
 		return bOk;
@@ -481,28 +444,20 @@ namespace {
 	}
 
 	void RestorePartitions(PartitionBackup* apBackups, uint32_t auiCount) {
-		__try {
-			while (auiCount) {
-				--auiCount;
-				if (apBackups[auiCount].pPartition)
-					apBackups[auiCount].pPartition->ucEnabled = apBackups[auiCount].ucSavedEnabled;
-				if (apBackups[auiCount].pVisible)
-					*apBackups[auiCount].pVisible = apBackups[auiCount].ucSavedVisible;
-			}
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
+		while (auiCount) {
+			--auiCount;
+			if (apBackups[auiCount].pPartition)
+				apBackups[auiCount].pPartition->ucEnabled = apBackups[auiCount].ucSavedEnabled;
+			if (apBackups[auiCount].pVisible)
+				*apBackups[auiCount].pVisible = apBackups[auiCount].ucSavedVisible;
 		}
 	}
 
 	void RestoreFlags(FlagBackup* apBackups, uint32_t auiCount) {
-		__try {
-			while (auiCount) {
-				--auiCount;
-				if (apBackups[auiCount].pFlags)
-					*apBackups[auiCount].pFlags = apBackups[auiCount].uiSavedFlags;
-			}
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
+		while (auiCount) {
+			--auiCount;
+			if (apBackups[auiCount].pFlags)
+				*apBackups[auiCount].pFlags = apBackups[auiCount].uiSavedFlags;
 		}
 	}
 
@@ -561,14 +516,7 @@ namespace {
 			PartitionBackup* apBackups, uint32_t auiMax, uint32_t& arCount) {
 		arCount = 0;
 		uint32_t uiUnusedFlagCount = 0;
-		bool bOk = false;
-		__try {
-			bOk = CullTree(apBody3p, arConfig, apBackups, auiMax, arCount,
-				nullptr, 0, uiUnusedFlagCount, 0);
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
-			bOk = false;
-		}
+		bool bOk = CullTree(apBody3p, arConfig, apBackups, auiMax, arCount, nullptr, 0, uiUnusedFlagCount, 0);
 		if (!bOk)
 			RestorePartitions(apBackups, arCount);
 		return bOk;
@@ -584,15 +532,9 @@ namespace {
 		if (!apBody3p)
 			return false;
 
-		bool bOk = false;
-		__try {
-			bOk = CullTree(apBody3p, arConfig,
-				apPartitionBackups, auiMaxPartitions, arPartitionCount,
-				apFlagBackups, auiMaxFlags, arFlagCount, 0);
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
-			bOk = false;
-		}
+		bool bOk = CullTree(apBody3p, arConfig,
+			apPartitionBackups, auiMaxPartitions, arPartitionCount,
+			apFlagBackups, auiMaxFlags, arFlagCount, 0);
 		if (!bOk) {
 			RestoreFlags(apFlagBackups, arFlagCount);
 			RestorePartitions(apPartitionBackups, arPartitionCount);
@@ -679,59 +621,49 @@ namespace {
 	}
 
 	void RestoreShaders(ShaderBackup* apBackups, uint32_t auiCount) {
-		__try {
-			while (auiCount) {
-				--auiCount;
-				BSShaderProperty* pShader = apBackups[auiCount].pShader;
-				if (!pShader)
-					continue;
-				pShader->ulFlags[0] = apBackups[auiCount].uiSavedFlags1;
-				pShader->ulFlags[1] = apBackups[auiCount].uiSavedFlags2;
-				*reinterpret_cast<float*>(
-					reinterpret_cast<uint8_t*>(pShader) + kOffShader_RefractionPower) =
-					apBackups[auiCount].fSavedRefractionPower;
-				pShader->InvalidateState();
-			}
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
+		while (auiCount) {
+			--auiCount;
+			BSShaderProperty* pShader = apBackups[auiCount].pShader;
+			if (!pShader)
+				continue;
+			pShader->ulFlags[0] = apBackups[auiCount].uiSavedFlags1;
+			pShader->ulFlags[1] = apBackups[auiCount].uiSavedFlags2;
+			*reinterpret_cast<float*>(
+				reinterpret_cast<uint8_t*>(pShader) + kOffShader_RefractionPower) =
+				apBackups[auiCount].fSavedRefractionPower;
+			pShader->InvalidateState();
 		}
 	}
 
-	bool PatchRefractionGuarded(NiNode* apBody3p, float afRefraction,
-			ShaderBackup* apBackups, uint32_t auiMax, uint32_t& arCount) {
+	bool PatchRefractionGuarded(NiNode* apBody3p, float afRefraction, ShaderBackup* apBackups, uint32_t auiMax, uint32_t& arCount) {
 		arCount = 0;
 		if (afRefraction <= 0.0f)
 			return true;
+
 		if (afRefraction > 1.0f)
 			afRefraction = 1.0f;
 
-		bool bOk = false;
-		__try {
-			bOk = PatchRefractionTree(apBody3p, afRefraction, apBackups, auiMax, arCount, 0);
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
-			bOk = false;
-		}
+		bool bOk = PatchRefractionTree(apBody3p, afRefraction, apBackups, auiMax, arCount, 0);
+
 		if (!bOk)
 			RestoreShaders(apBackups, arCount);
+
 		return bOk;
 	}
 
 	void RestoreInjectedBody(InjectionState& arState) {
 		if (!arState.bActive)
 			return;
-		__try {
-			if (arState.uiShaderCount)
-				RestoreShaders(arState.kShaders, arState.uiShaderCount);
-			if (arState.uiPartitionCount)
-				RestorePartitions(arState.kPartitions, arState.uiPartitionCount);
-			if (arState.uiTransformCount)
-				RestoreTransforms(arState.kTransforms, arState.uiTransformCount);
-			if (arState.pIs1stPerson)
-				*arState.pIs1stPerson = arState.bSavedIs1stPerson;
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
-		}
+
+		if (arState.uiShaderCount)
+			RestoreShaders(arState.kShaders, arState.uiShaderCount);
+		if (arState.uiPartitionCount)
+			RestorePartitions(arState.kPartitions, arState.uiPartitionCount);
+		if (arState.uiTransformCount)
+			RestoreTransforms(arState.kTransforms, arState.uiTransformCount);
+		if (arState.pIs1stPerson)
+			*arState.pIs1stPerson = arState.bSavedIs1stPerson;
+
 		arState.bActive = false;
 	}
 
@@ -814,16 +746,11 @@ namespace {
 	HookUtils::CallDetour g_callDetours[kHookCount];
 
 	void RestoreBodyFlagsGuarded(uint32_t* apFlags, uint32_t auiSaved) {
-		__try {
-			*apFlags = auiSaved;
-		}
-		__except (EXCEPTION_EXECUTE_HANDLER) {
-		}
+		*apFlags = auiSaved;
 	}
 
 	template <uint32_t aiHookIndex>
-	void __fastcall HookedDrawScene(void* apThis, void* edx, void* apSun,
-			int abRenderHands, int abIsWireframe, int abIsInVATS) {
+	void __fastcall HookedDrawScene(void* apThis, void* edx, void* apSun, int abRenderHands, int abIsWireframe, int abIsInVATS) {
 		uint32_t* pBodyFlags = nullptr;
 		uint32_t uiSaved = 0;
 		PartitionBackup kPreviewPartitions[kPartitionMax];
@@ -834,14 +761,9 @@ namespace {
 		const bool bSuppressBody = g_enabled || iSuppressFrames > 0;
 		if (bSuppressBody) {
 			if (NiNode* pBody3p = GetPlayerBodyRootFast()) {
-				__try {
-					pBodyFlags = &pBody3p->m_uiFlags.GetField();
-					uiSaved = *pBodyFlags;
-					*pBodyFlags = uiSaved | kNiFlagHidden;
-				}
-				__except (EXCEPTION_EXECUTE_HANDLER) {
-					pBodyFlags = nullptr;
-				}
+				pBodyFlags = &pBody3p->m_uiFlags.GetField();
+				uiSaved = *pBodyFlags;
+				*pBodyFlags = uiSaved | kNiFlagHidden;
 			}
 		} else {
 			const CullConfig kPreviewConfig = GetCullConfig();
@@ -852,20 +774,17 @@ namespace {
 						kPreviewFlags, kFlagMax, uiPreviewFlagCount);
 			}
 		}
-		__try {
-			ThisCall(g_callDetours[aiHookIndex].GetOverwrittenAddr(),
-				apThis, apSun, abRenderHands, abIsWireframe, abIsInVATS);
-		}
-		__finally {
-			if (uiPreviewFlagCount)
-				RestoreFlags(kPreviewFlags, uiPreviewFlagCount);
-			if (uiPreviewPartitionCount)
-				RestorePartitions(kPreviewPartitions, uiPreviewPartitionCount);
-			if (iSuppressFrames > 0)
-				InterlockedDecrement(&g_disableSuppressFrameBudget);
-			if (pBodyFlags)
-				RestoreBodyFlagsGuarded(pBodyFlags, uiSaved);
-		}
+
+		ThisCall(g_callDetours[aiHookIndex].GetOverwrittenAddr(), apThis, apSun, abRenderHands, abIsWireframe, abIsInVATS);
+
+		if (uiPreviewFlagCount)
+			RestoreFlags(kPreviewFlags, uiPreviewFlagCount);
+		if (uiPreviewPartitionCount)
+			RestorePartitions(kPreviewPartitions, uiPreviewPartitionCount);
+		if (iSuppressFrames > 0)
+			InterlockedDecrement(&g_disableSuppressFrameBudget);
+		if (pBodyFlags)
+			RestoreBodyFlagsGuarded(pBodyFlags, uiSaved);
 	}
 
 	// Keep this out of the hook frame. Its locals are about 60 KB.
@@ -875,17 +794,14 @@ namespace {
 		InjectionState kInjected;
 		float fRefraction = 0.0f;
 		const bool bHasRefraction = PlayerHasActiveRefraction(&fRefraction);
-		__try {
-			if (bHasRefraction == abRefractionPass)
-				InjectBodyIntoAccum(apCamera, apAccum, kInjected, abRefractionPass ? fRefraction : 0.0f);
-			if (abRefractionPass)
-				ThisCall(auiOriginalTarget, apAccum, apCamera, apTexture);
-			else
-				CdeclCall(auiOriginalTarget, apCamera, apAccum);
-		}
-		__finally {
-			RestoreInjectedBody(kInjected);
-		}
+		if (bHasRefraction == abRefractionPass)
+			InjectBodyIntoAccum(apCamera, apAccum, kInjected, abRefractionPass ? fRefraction : 0.0f);
+		if (abRefractionPass)
+			ThisCall(auiOriginalTarget, apAccum, apCamera, apTexture);
+		else
+			CdeclCall(auiOriginalTarget, apCamera, apAccum);
+			
+		RestoreInjectedBody(kInjected);
 	}
 
 	bool IsViewmodelAccum(BSShaderAccumulator* apAccum) {
@@ -906,9 +822,7 @@ namespace {
 	}
 
 	template <uint32_t aiHookIndex>
-	void __fastcall HookedRenderNormals(BSShaderAccumulator* apAccum, void* edx,
-			NiCamera* apCamera, void* apTexture) {
-		(void)edx;
+	void __fastcall HookedRenderNormals(BSShaderAccumulator* apAccum, void* edx, NiCamera* apCamera, void* apTexture) {
 		const uintptr_t uiOriginalTarget = g_callDetours[aiHookIndex].GetOverwrittenAddr();
 		if (g_enabled && IsViewmodelAccum(apAccum)) {
 			CallWithInjectedBody(true, uiOriginalTarget, apCamera, apAccum, apTexture);

--- a/JG/internal/JG/PlayerBodyOverlay.hpp
+++ b/JG/internal/JG/PlayerBodyOverlay.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+
+namespace PlayerBodyOverlay {
+
+	void Install();
+	void Reset();
+	int32_t SetEnabled(bool abEnable, int32_t aiDisableSuppressFrames);
+	bool IsEnabled();
+	uint32_t SetCullParts(int32_t aiMode, uint32_t auiPartBits);
+	uint32_t GetCullPartBits();
+	uint32_t BuildPartBits(const int32_t* apParts, uint32_t auiCount);
+}

--- a/JG/internal/havok.h
+++ b/JG/internal/havok.h
@@ -316,7 +316,19 @@ public:
 	virtual void	Unk_37(void);
 	virtual void	Unk_38(void);
 
-	uint32_t			unk10;		// 10
+	uint32_t		eMaterialType;
+
+	HavokMaterialType GetMaterial() const {
+		return ThisCall<HavokMaterialType>(0x6205A0, this);
+	}
+
+	HavokMaterialType GetSubshapeMaterial(uint32_t auiKey) const {
+		return ThisCall<HavokMaterialType>(0xC84F10, this, auiKey);
+	}
+
+	static bhkShape* Getbhk(const hkpShape* apShape) {
+		return CdeclCall<bhkShape*>(0x4A3A40, apShape);
+	}
 };
 
 // 14
@@ -541,6 +553,29 @@ public:
 	uint32_t				unk68;		// 68
 	void* unk6C;		// 6C
 	uint32_t				unk70[9];	// 70
+
+	struct ObjectRecData {
+		union Data {
+			bool		b[4];
+			char		c[4];
+			uint16_t	us[2];
+			int32_t		i;
+			float		f;
+			void*		p;
+			uint32_t	ui;
+		};
+
+		bhkWorld*	pWorld; 
+		bool		bRecurse;
+		uint32_t	eAction;
+		Data		uData[4];
+	};
+
+	using pfnRecFunc = void(__cdecl*)(bhkNiCollisionObject* apCollisionObject, ObjectRecData& arData);
+
+	static void DoObjectRec(NiAVObject* apObject, ObjectRecData& arData, pfnRecFunc apFunc) {
+		CdeclCall(0xC68900, apObject, &arData, apFunc);
+	}
 };
 static_assert(sizeof(bhkWorld) == 0x94);
 

--- a/JG/nvse_plugin_example.vcxproj
+++ b/JG/nvse_plugin_example.vcxproj
@@ -206,6 +206,7 @@ copy "$(TargetDir)$(TargetName).pdb" "C:\Symbols\$(TargetName).pdb"
     <ClCompile Include="functions\fn_form.cpp" />
     <ClCompile Include="functions\fn_gamebryo.cpp" />
     <ClCompile Include="functions\fn_gameplay.cpp" />
+    <ClCompile Include="functions\fn_hit.cpp" />
     <ClCompile Include="functions\fn_math.cpp" />
     <ClCompile Include="functions\fn_mediaset.cpp" />
     <ClCompile Include="functions\fn_region.cpp" />
@@ -306,6 +307,7 @@ copy "$(TargetDir)$(TargetName).pdb" "C:\Symbols\$(TargetName).pdb"
     <ClCompile Include="internal\JG\LandRemapping.cpp" />
     <ClCompile Include="internal\JG\MediaLocationControllerTweaks.cpp" />
     <ClCompile Include="internal\JG\NPCAccuracy.cpp" />
+    <ClCompile Include="internal\JG\PlayerBodyOverlay.cpp" />
     <ClCompile Include="internal\JG\QuestObjectiveDisplayFix.cpp" />
     <ClCompile Include="internal\JG\RadioSkipOGGWAVPatch.cpp" />
     <ClCompile Include="internal\JG\RSMBarberHook.cpp" />
@@ -361,6 +363,7 @@ copy "$(TargetDir)$(TargetName).pdb" "C:\Symbols\$(TargetName).pdb"
     <ClInclude Include="functions\fn_form.h" />
     <ClInclude Include="functions\fn_gamebryo.h" />
     <ClInclude Include="functions\fn_gameplay.h" />
+    <ClInclude Include="functions\fn_hit.h" />
     <ClInclude Include="functions\fn_math.h" />
     <ClInclude Include="functions\fn_mediaset.h" />
     <ClInclude Include="functions\fn_region.h" />
@@ -576,6 +579,7 @@ copy "$(TargetDir)$(TargetName).pdb" "C:\Symbols\$(TargetName).pdb"
     <ClInclude Include="internal\JG\LandRemapping.hpp" />
     <ClInclude Include="internal\JG\MediaLocationControllerTweaks.hpp" />
     <ClInclude Include="internal\JG\NPCAccuracy.hpp" />
+    <ClInclude Include="internal\JG\PlayerBodyOverlay.hpp" />
     <ClInclude Include="internal\JG\QuestObjectiveDisplayFix.hpp" />
     <ClInclude Include="internal\JG\RadioSkipOGGWAVPatch.hpp" />
     <ClInclude Include="internal\JG\RSMBarberHook.hpp" />

--- a/JG/nvse_plugin_example.vcxproj.filters
+++ b/JG/nvse_plugin_example.vcxproj.filters
@@ -220,6 +220,9 @@
     <ClCompile Include="functions\fn_gameplay.cpp">
       <Filter>functions</Filter>
     </ClCompile>
+    <ClCompile Include="functions\fn_hit.cpp">
+      <Filter>functions</Filter>
+    </ClCompile>
     <ClCompile Include="functions\fn_math.cpp">
       <Filter>functions</Filter>
     </ClCompile>
@@ -466,6 +469,9 @@
     <ClCompile Include="internal\JG\CameraOverlay.cpp">
       <Filter>internal\JG\Features</Filter>
     </ClCompile>
+    <ClCompile Include="internal\JG\PlayerBodyOverlay.cpp">
+      <Filter>internal\JG\Features</Filter>
+    </ClCompile>
     <ClCompile Include="internal\JG\BarterFilter.cpp">
       <Filter>internal\JG\Features</Filter>
     </ClCompile>
@@ -575,6 +581,9 @@
       <Filter>functions</Filter>
     </ClInclude>
     <ClInclude Include="functions\fn_gameplay.h">
+      <Filter>functions</Filter>
+    </ClInclude>
+    <ClInclude Include="functions\fn_hit.h">
       <Filter>functions</Filter>
     </ClInclude>
     <ClInclude Include="functions\fn_math.h">
@@ -1265,6 +1274,9 @@
       <Filter>internal\JG\Features</Filter>
     </ClInclude>
     <ClInclude Include="internal\JG\CameraOverlay.hpp">
+      <Filter>internal\JG\Features</Filter>
+    </ClInclude>
+    <ClInclude Include="internal\JG\PlayerBodyOverlay.hpp">
       <Filter>internal\JG\Features</Filter>
     </ClInclude>
     <ClInclude Include="internal\JG\BarterFilter.hpp">

--- a/nvse/nvse/GameForms.h
+++ b/nvse/nvse/GameForms.h
@@ -883,30 +883,29 @@ public:
 	TESActorBaseData();
 	~TESActorBaseData();
 
-	virtual void			Fn_04(TESForm* selectedForm);	// Called during form initialization after LoadForm and InitForm
-	// flags access
-	virtual bool			Fn_05(void);	// 00100000
-	virtual bool			Fn_06(void);	// 00200000
-	virtual bool			Fn_07(void);	// 10000000
-	virtual bool			Fn_08(void);	// 20000000
-	virtual bool			GetAsForm(void);	// 80000000
-	virtual bool			Fn_0A(void);	// 00400000
-	virtual bool			Fn_0B(void);	// 00400000
-	virtual bool			Fn_0C(void);	// 00800000
-	virtual bool			Fn_0D(void);
-	virtual bool			Fn_0E(void);
-	virtual bool			Fn_0F(void);
-	virtual bool			Fn_10(void);
-	virtual bool			Fn_11(void);
-	virtual bool			Fn_12(void);
-	virtual void			Fn_13(void* arg);
-	virtual bool			Fn_14(void);
-	virtual void			Fn_15(void* arg);
-	virtual uint32_t			Fn_16(void);
-	virtual void			Fn_17(void* arg);
-	virtual uint32_t			Fn_18(void);	// return unk08
-	virtual float			Fn_19(void);	// return unk14
-	virtual BGSVoiceType* GetVoiceType(void);
+	virtual void			CopyFromTemplateForm(TESForm* apForm);
+	virtual bool			GetNoVATSmelee() const;
+	virtual bool			GetAllowPCDialogue() const;
+	virtual bool			GetAllowPickpocket() const;
+	virtual bool			GetIsGhost() const;
+	virtual bool			GetInvulnerable() const;
+	virtual bool			GetCantOpenDoors() const;
+	virtual bool			GetCanBeAllRaces() const;
+	virtual bool			GetAutoCalcServiceFlags() const;
+	virtual bool			GetNoPersuasion() const;
+	virtual bool			GetNoLeftArm() const;
+	virtual bool			GetNoRightArm() const;
+	virtual bool			GetNoHead() const;
+	virtual bool			GetNoShadow() const;
+	virtual bool			GetNoBloodSpray() const;
+	virtual void			SetNoBloodSpray(bool abVal);
+	virtual bool			GetNoBloodDecal() const;
+	virtual void			SetNoBloodDecal(bool abVal);
+	virtual uint32_t		GetBloodImpactMaterial() const;
+	virtual void			SetBloodImpactMaterial(uint32_t aeType);
+	virtual uint32_t		GetFatigue() const;
+	virtual float			GetKarma() const;
+	virtual BGSVoiceType*	GetVoiceType() const;
 
 	enum {
 		kFlags_Female = 1 << 0,
@@ -5075,7 +5074,7 @@ public:
 	uint8_t				flags;					// 60
 	uint8_t				pad61;					// 61
 	uint8_t				healthPercent;			// 62
-	uint8_t				actorValue;				// 63
+	int8_t				actorValue;				// 63
 	uint8_t				toHitChance;			// 64
 	uint8_t				explChance;				// 65
 	uint8_t				explDebrisCount;		// 66
@@ -5101,6 +5100,10 @@ public:
 	void SetFlag(uint32_t pFlag, bool bEnable) {
 		if (bEnable) flags |= pFlag;
 		else flags &= ~pFlag;
+	}
+
+	int8_t GetActorValue() const {
+		return actorValue;
 	}
 };
 
@@ -5134,6 +5137,10 @@ public:
 	BGSPreloadable	preloadable;		// 030
 	BGSBodyPart* bodyParts[15];		// 034
 	BGSRagdoll* ragDoll;			// 070
+
+	BGSBodyPart* GetBodyPart(BODY_PART_TYPE aePart) const {
+		return ThisCall<BGSBodyPart*>(0x5E50F0, this, aePart);
+	}
 };
 static_assert(sizeof(BGSBodyPartData) == 0x74);
 

--- a/nvse/nvse/GameObjects.h
+++ b/nvse/nvse/GameObjects.h
@@ -439,7 +439,7 @@ public:
 	virtual void		Unk_CB(void);
 	virtual void		Unk_CC(void);
 	virtual void		Unk_CD(void);
-	virtual void		Unk_CE(void);
+	virtual bool		DoDamage(float afHealth, float afFatigue, Actor* apSource);
 	virtual void		Unk_CF(void);
 	virtual void		Unk_D0(void);
 	virtual void		Unk_D1(void);
@@ -712,6 +712,22 @@ public:
 
 	float GetRunSpeed() {
 		return ThisCall<float>(0x884EB0, this);
+	}
+
+	void AttackAlarm(TESObjectREFR* apAttacker, bool abMinorCrime, bool abModDisposition = true) {
+		ThisCall(0x8C0460, this, apAttacker, abMinorCrime, abModDisposition);
+	}
+
+	void SetAnimAction(ANIMATION_ACTION aeAction, BSAnimGroupSequence* apSequence) {
+		ThisCall(0x8A73E0, this, aeAction, apSequence);
+	}
+
+	bool HasBlood() const {
+		return ThisCall<bool>(0x87F260, this);
+	}
+
+	NiNode* GetClosestBone(NiPoint3 akStartingPos, NiPoint3 akImpactPos) const {
+		return ThisCall<NiNode*>(0x8B3D70, this, akStartingPos, akImpactPos);
 	}
 };
 

--- a/nvse/nvse/GameProcess.h
+++ b/nvse/nvse/GameProcess.h
@@ -24,8 +24,13 @@ class bhkCharacterController;
 struct DetectionData;
 
 // 64
-struct ActorHitData
-{
+struct ActorHitData {
+	ActorHitData() {
+		ThisCall(0x9B4D90, this);
+	}
+	~ActorHitData() = default;
+
+
 	Actor				*source;		// 00
 	Actor				*target;		// 04
 	union								// 08
@@ -50,7 +55,15 @@ struct ActorHitData
 	uint32_t				unk54;			// 54
 	uint32_t				flags;			// 58
 	float				dmgMult;		// 5C
-	uint32_t				unk60;			// 60	Unused
+	int32_t				iRefCount;			// 60
+
+	void IncRefCount() {
+		InterlockedIncrement(&reinterpret_cast<uint32_t&>(iRefCount));
+	}
+
+	void DecRefCount() {
+		ThisCall(0x87CEA0, this);
+	}
 };
 
 class Animation;
@@ -507,7 +520,7 @@ public:
 	virtual void	Unk_1B1();
 	virtual void	Unk_1B2();
 	virtual void	Unk_1B3();
-	virtual void	Unk_1B4();
+	virtual NiNode* GetDamageNode(BODY_PART_TYPE aeBodyPart) const;
 	virtual void	Unk_1B5();
 	virtual void	Unk_1B6();
 	virtual void	Unk_1B7();
@@ -547,12 +560,12 @@ public:
 	virtual void	Unk_1D9();
 	virtual void	Unk_1DA();
 	virtual float	GetRadsSec();
-	virtual ActorHitData *GetHitData();
-	virtual void	CopyHitData(ActorHitData *hitData);
-	virtual void	ResetHitData();
-	virtual ActorHitData *GetHitData254();
-	virtual void	CopyHitData254(ActorHitData *hitData);
-	virtual void	ResetHitData254();
+	virtual ActorHitData* GetLastHitData() const;
+	virtual void	SetLastHitData(ActorHitData* apHitData);
+	virtual void	ClearLastHitData();
+	virtual ActorHitData* GetLastAttackHitData();
+	virtual void	SetLastAttackHitData(ActorHitData* apHitData);
+	virtual void	ClearLastAttackHitData();
 	virtual void	Unk_1E2();
 	virtual void	Unk_1E3();
 	virtual void	Unk_1E4();
@@ -741,6 +754,10 @@ public:
 
 	void ReloadTargets(bool abReload) {
 		ThisCall(0x499240, this, abReload);
+	}
+
+	void ClearGroup(ANIM_GROUP_SECTION aeSection, float afEaseOutTime) {
+		ThisCall(0x496080, this, aeSection, afEaseOutTime);
 	}
 };
 static_assert(sizeof(Animation) == 0x12C);

--- a/nvse/nvse/GameScript.h
+++ b/nvse/nvse/GameScript.h
@@ -117,6 +117,10 @@ public:
 	static bool	RunScriptLine(const char *text, TESObjectREFR *object = NULL);
 	static bool	RunScriptLine2(const char *text, TESObjectREFR *object = NULL, bool bSuppressOutput = true);
 
+	static bool SetActionFlag(TESForm* apForm, ExtraDataList* apList, uint32_t aeEvent) {
+		return CdeclCall<bool>(0x5AC750, apForm, apList, aeEvent);
+	}
+
 	// no changed flags (TESForm flags)
 	MEMBER_FN_PREFIX(Script);
 #if 1

--- a/nvse/nvse/ParamInfos.h
+++ b/nvse/nvse/ParamInfos.h
@@ -1177,3 +1177,70 @@ static ParamInfo kParamsApplyModelTextureSwap[] =
 	{ "Reference", kParamType_ObjectRef, 1 },
 	{ "First Person", kParamType_Integer, 1 },
 };
+
+static ParamInfo kParams_FourFloats[] =
+{
+	{ "Float", kParamType_Float, 0 },
+	{ "Float", kParamType_Float, 0 },
+	{ "Float", kParamType_Float, 0 },
+	{ "Float", kParamType_Float, 0 },
+};
+
+static ParamInfo kParams_ApplyHitData[] =
+{
+	{ "Attacker",		kParamType_Actor,		1 },
+	{ "Health Damage",	kParamType_Float,		1 },
+	{ "Fatigue Damage",	kParamType_Float,		1 },
+	{ "Limb Damage",	kParamType_Float,		1 },
+	{ "Weapon",			kParamType_ObjectID,	1 },
+	{ "Hit Location",	kParamType_Integer,		1 },
+	{ "Flags",			kParamType_Integer,		1 },
+	{ "Fire OnHit",		kParamType_Integer,		1 },
+	{ "Fire Alarm",		kParamType_Integer,		1 },
+	{ "Fire Blood",		kParamType_Integer,		1 },
+	{ "Fire Sound",		kParamType_Integer,		1 },
+	{ "Skip Clear",		kParamType_Integer,		1 },
+};
+
+static ParamInfo kParams_GetObjectMaterial[] =
+{
+	{ "Cam X",	kParamType_Float,	1 },
+	{ "Cam Y",	kParamType_Float,	1 },
+	{ "Cam Z",	kParamType_Float,	1 },
+	{ "Hit X",	kParamType_Float,	1 },
+	{ "Hit Y",	kParamType_Float,	1 },
+	{ "Hit Z",	kParamType_Float,	1 },
+	{ "Layer",	kParamType_Integer,	1 },
+};
+
+static ParamInfo kParams_ApplyObjectImpact[] =
+{
+	{ "Material",	kParamType_Integer,		1 },
+	{ "Weapon",		kParamType_ObjectID,	1 },
+	{ "Sound",		kParamType_Integer,		1 },
+	{ "Particle",	kParamType_Integer,		1 },
+	{ "Pos X",		kParamType_Float,		1 },
+	{ "Pos Y",		kParamType_Float,		1 },
+	{ "Pos Z",		kParamType_Float,		1 },
+};
+
+static ParamInfo kParams_Set3rdPersonOverlayCullParts[] =
+{
+	{ "Mode",	kParamType_Integer, 0 },
+	{ "Part 0",	kParamType_Integer, 1 },
+	{ "Part 1",	kParamType_Integer, 1 },
+	{ "Part 2",	kParamType_Integer, 1 },
+	{ "Part 3",	kParamType_Integer, 1 },
+	{ "Part 4",	kParamType_Integer, 1 },
+	{ "Part 5",	kParamType_Integer, 1 },
+	{ "Part 6",	kParamType_Integer, 1 },
+	{ "Part 7",	kParamType_Integer, 1 },
+	{ "Part 8",	kParamType_Integer, 1 },
+	{ "Part 9",	kParamType_Integer, 1 },
+	{ "Part 10",	kParamType_Integer, 1 },
+	{ "Part 11",	kParamType_Integer, 1 },
+	{ "Part 12",	kParamType_Integer, 1 },
+	{ "Part 13",	kParamType_Integer, 1 },
+	{ "Part 14",	kParamType_Integer, 1 },
+	{ "Part 15",	kParamType_Integer, 1 },
+};


### PR DESCRIPTION
ApplyHitData, GetObjectMaterial, ApplyObjectImpact, InterruptWeaponAnim, ApplyRagdollForce, Set3rdPersonOverlay, Set3rdPersonOverlayCullParts.

The overlay renders the 3rd person body into the 1st person viewmodel pass and hides it in the world pass. Five call site detours (0x870AE8, 0x870E18, 0x87550F, 0x8755F4, 0x87590A), installed lazily on first use, fail closed if any site is already hooked. No overlap with CameraOverlay or JIP patch sites. InterruptWeaponAnim deliberately won't touch attack actions, the engine can't handle a cleared attack sequence.